### PR TITLE
feat(getDockerHubUrl): support official library images in API URL generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mqdockerup",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "A Node.js application that pushes information about running Docker containers to an MQTT server.",
   "main": "index.js",
   "scripts": {

--- a/src/services/DockerService.ts
+++ b/src/services/DockerService.ts
@@ -1,9 +1,8 @@
 import Docker from "dockerode";
 import { ContainerInspectInfo } from "dockerode";
 import axios from "axios";
-import logger from "./LoggerService"
+import logger from "./LoggerService";
 import HomeassistantService from "./HomeassistantService";
-
 
 /**
  * Represents a Docker service for managing Docker containers and images.
@@ -41,13 +40,12 @@ export default class DockerService {
     tag: string
   ): Promise<{ registry: any; response: any }> {
     try {
-      const response = await axios.get(
-        `https://registry.hub.docker.com/v2/repositories/${imageName}/tags?name=${tag}`
-      );
+      const url = getDockerHubUrl(imageName, tag);
+      const response = await axios.get(url);
       if (response.status === 200) {
         return { registry: "Docker Hub", response };
       }
-    } catch (error) { }
+    } catch (error) {}
 
     const registryList = [
       {
@@ -113,6 +111,26 @@ export default class DockerService {
   }
 
   /**
+   * Generates the Docker Hub API URL to fetch the image and tag information.
+   *
+   * @param {string} image - The name of the Docker image. It can be a user image (e.g., 'micrib/mqdockerup') or an official library image without the 'library/' prefix (e.g., 'debian').
+   * @param {string} tag - The tag of the Docker image (e.g., 'latest').
+   * @returns {string} - The Docker Hub API URL for the specified image and tag.
+   */
+  public static getDockerHubUrl(image: string, tag: string): string {
+    const baseUrl = "https://hub.docker.com/v2/repositories";
+    const parts = image.split("/");
+
+    if (parts.length === 1) {
+      // If the image name doesn't include a '/', it's an official library image
+      return `${baseUrl}/library/${image}/tags?name=${tag}`;
+    } else {
+      // If the image name includes a '/', it's a user image
+      return `${baseUrl}/${image}/tags?name=${tag}`;
+    }
+  }
+
+  /**
    * Gets the private registry for the specified image name.
    *
    * @param imageName - The name of the Docker image.
@@ -148,7 +166,7 @@ export default class DockerService {
     const container = DockerService.docker.getContainer(containerId);
     const info = await container.inspect();
     const image = info.Config.Image;
-    const imageName = image.split(":")[0];;
+    const imageName = image.split(":")[0];
 
     // Catch the case if its trying to update MqDockerUp itself
     if (imageName.toLowerCase() === "mqdockerup") {
@@ -162,72 +180,71 @@ export default class DockerService {
     let totalSize = 0;
     let lastProgressEvent = { progressDetail: { current: 0, total: 0 } };
 
-    await DockerService.docker.pull(
-      image,
-      async (err: any, stream: any) => {
-        if (err) {
-          logger.error("Pulling Error: " + err);
-          return;
-        }
-        // use modem.followProgress to get progress events
-        DockerService.docker.modem.followProgress(
-          stream,
-          async (err: any, output: any) => {
-            if (err) {
-              logger.error("Stream Error: " + err);
-              return;
-            }
-
-            logger.info("Image pulled successfully");
-            const containerConfig: any = {
-              ...info,
-              ...info.Config,
-              ...info.HostConfig,
-              ...info.NetworkSettings,
-              name: info.Name,
-              Image: image,
-            };
-
-            const mounts = info.Mounts;
-            const binds = mounts.map(
-              (mount) => `${mount.Source}:${mount.Destination}`
-            );
-            containerConfig.HostConfig.Binds = binds;
-
-            await container.stop();
-            await container.remove();
-
-            const newContainer = await DockerService.docker.createContainer(
-              containerConfig
-            );
-            await newContainer.start();
-
-            return newContainer;
-          },
-          function (event) {
-            logger.info(`Status: ${event.status}`);
-            // check if progressDetail exists
-            if (event.progressDetail) {
-              const current = event.progressDetail.current || 0;
-              const total = event.progressDetail.total || 0;
-
-              // update total progress and size
-              totalProgress += current;
-              totalSize += total;
-
-              const percentage = Math.round((totalProgress / totalSize) * 100);
-
-              // print percentage
-              logger.info(`Total progress: ${totalProgress}/${totalSize} (${percentage}%)`);
-
-              // Send Progress to MQTT 
-              // TODO: Needs to be fixed
-              // HomeassistantService.publishUpdateProgressMessage(info, client, percentage, totalSize - totalProgress, event.status, false);
-            }
-          }
-        );
+    await DockerService.docker.pull(image, async (err: any, stream: any) => {
+      if (err) {
+        logger.error("Pulling Error: " + err);
+        return;
       }
-    );
+      // use modem.followProgress to get progress events
+      DockerService.docker.modem.followProgress(
+        stream,
+        async (err: any, output: any) => {
+          if (err) {
+            logger.error("Stream Error: " + err);
+            return;
+          }
+
+          logger.info("Image pulled successfully");
+          const containerConfig: any = {
+            ...info,
+            ...info.Config,
+            ...info.HostConfig,
+            ...info.NetworkSettings,
+            name: info.Name,
+            Image: image,
+          };
+
+          const mounts = info.Mounts;
+          const binds = mounts.map(
+            (mount) => `${mount.Source}:${mount.Destination}`
+          );
+          containerConfig.HostConfig.Binds = binds;
+
+          await container.stop();
+          await container.remove();
+
+          const newContainer = await DockerService.docker.createContainer(
+            containerConfig
+          );
+          await newContainer.start();
+
+          return newContainer;
+        },
+        function (event) {
+          logger.info(`Status: ${event.status}`);
+          // check if progressDetail exists
+          if (event.progressDetail) {
+            const current = event.progressDetail.current || 0;
+            const total = event.progressDetail.total || 0;
+
+            // update total progress and size
+            totalProgress += current;
+            totalSize += total;
+
+            const percentage = Math.round((totalProgress / totalSize) * 100);
+
+            // print percentage
+            logger.info(
+              `Total progress: ${totalProgress}/${totalSize} (${percentage}%)`
+            );
+
+            // Send Progress to MQTT
+            // TODO: Needs to be fixed
+            // HomeassistantService.publishUpdateProgressMessage(info, client, percentage, totalSize - totalProgress, event.status, false);
+          }
+        }
+      );
+    });
   }
 
   /**
@@ -298,20 +315,28 @@ export default class DockerService {
    * @returns A promise that resolves to the new Docker container.
    * @throws An error if the container could not be created.
    */
-  public static async createContainer(containerConfig: any): Promise<Docker.Container> {
-    const container = await DockerService.docker.createContainer({ ...containerConfig });
+  public static async createContainer(
+    containerConfig: any
+  ): Promise<Docker.Container> {
+    const container = await DockerService.docker.createContainer({
+      ...containerConfig,
+    });
 
     return container;
   }
 
   /**
- * Checks if a container exists.
- * @param containerImage - The name of the Docker image to check.
- * @returns A promise that resolves to true if the container exists.
- */
-public static checkIfContainerExists(containerImage: string): Promise<boolean> {
-  return DockerService.docker.listContainers()
-    .then((containers) => containers.some((container) => container.Image === containerImage));
-}
-
+   * Checks if a container exists.
+   * @param containerImage - The name of the Docker image to check.
+   * @returns A promise that resolves to true if the container exists.
+   */
+  public static checkIfContainerExists(
+    containerImage: string
+  ): Promise<boolean> {
+    return DockerService.docker
+      .listContainers()
+      .then((containers) =>
+        containers.some((container) => container.Image === containerImage)
+      );
+  }
 }


### PR DESCRIPTION
Extend the getDockerHubUrl function to generate API URLs for fetching image and tag information for official library images without the 'library/' prefix, in addition to user images. Updated docblocks provide clarity on the function's purpose and parameters.