### PR TITLE
Add Github Access Token process to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ The access tokens configuration is specified in the `accessTokens` section of `c
 | `dockerhub` | `ACCESSTOKENS_DOCKERHUB` | `string` |  `""`   | The Dockerhub token, used to avoid the limitations of the DockerHub API _‼️Still Work In Progress_. |
 |    `github` |  `ACCESSTOKENS_GITHUB`   | `string` |  `""`   | The Github token, used to manage images on GitHub (`ghcr.io`) _⚠️Needed for this type of images_.   |
 
+> [!NOTE]
+>**To setup GitHub access token:**
+>
+>Setup a [Fine-grained personal access token](https://github.com/settings/personal-access-tokens) with the following permissions:
+> - Repository Access -> All repositories
+> - Repository Permissions (Read-Only):
+>   - Commit Statuses
+>   - Contents
+>   - Merge queues
+>   - Metadata
+>   - Pull requests
 
 ### Ignore Configuration
 


### PR DESCRIPTION
Added Github Access Token documentation to Readme File to fix #409 
Not sure if appropriate to also add a screenshot to the documentation. If provided with the steps for Dockerhub, I can add those steps to this pull request.
![Screenshot 2024-12-19 at 6 04 57 PM](https://github.com/user-attachments/assets/f5499f42-b24f-477a-b9ce-de636f40159f)