### PR TITLE
Update README.md - Correct Typo in Docker Compose Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ services:
   mqdockerup:
     image: micrib/mqdockerup:latest
     container_name: mqdockerup
-    hotname: mqdockerup
+    hostname: mqdockerup
     restart: always
     environment:
       MAIN_CONTAINERCHECKINTERVAL: "5m"


### PR DESCRIPTION
In Docker Compose Section of README.md the value "hotname" is wrong. I think this is a typo and should be "hostname"