### PR TITLE
Fix typo in config comment

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ accessTokens:
   dockerhub: ""
   github: ""
 
-# Ignore Configureation    
+# Ignore Configuration
 ignore:
   containers: ""
   updates: ""


### PR DESCRIPTION
## Summary
- correct a spelling error in config.yaml comment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840260e0f1c832999f94563fc4bce53