### PR TITLE
Fix environmental variable typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The configuration file `config.yaml` (`\app\config.yaml` in docker the container
 
 The main configuration is specified in the `main` section of `config.yaml`:
 
-|                     Name |     Enviromental Variable     | Type     | Default | Description                                                                                                                                                                                                                           |
+|                     Name |     Environmental Variable     | Type     | Default | Description                                                                                                                                                                                                                           |
 | -----------------------: | :---------------------------: | :------- | :-----: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `containerCheckInterval` | `MAIN_CONTAINERCHECKINTERVAL` | `string` | `"5m"`  | The interval at which container are checked and published/republished to the MQTT broker, must be in the format`[number][unit]`, where `[number]` is a positive integer and [`[unit]`](#unit).                                        |
 |    `updateCheckInterval` |  `MAIN_UPDATECHECKINTERVAL`   | `string` |  `""`   | The interval at which updates are checked and published/republished to the MQTT broker, must be in the format`[number][unit]`, where `[number]` is a positive integer and [`[unit]`](#unit) <br> (same of containerCheckInterval if `""`). |
@@ -63,7 +63,7 @@ The main configuration is specified in the `main` section of `config.yaml`:
 
 The MQTT configuration is specified in the `mqtt` section of `config.yaml`:
 
-|              Name | Enviromental Variable  |   Type    |         Default         | Description                                                                                             |
+|              Name | Environmental Variable  |   Type    |         Default         | Description                                                                                             |
 | ----------------: | :--------------------: | :-------: | :---------------------: | :------------------------------------------------------------------------------------------------------ |
 |   `connectionUri` |  `MQTT_CONNECTIONURI`  | `string`  | `mqtt://127.0.0.1:1883` | The URL of the MQTT broker to connect to.                                                               |
 |           `topic` |      `MQTT_TOPIC`      | `string`  |      `mqdockerup`       | The MQTT topic to publish updates to.                                                                   |
@@ -83,7 +83,7 @@ The MQTT configuration is specified in the `mqtt` section of `config.yaml`:
 
 The access tokens configuration is specified in the `accessTokens` section of `config.yaml`:
 
-|        Name |  Enviromental Variable   |   Type   | Default | Description                                                                                            |
+|        Name |  Environmental Variable   |   Type   | Default | Description                                                                                            |
 | ----------: | :----------------------: | :------: | :-----: | :----------------------------------------------------------------------------------------------------- |
 | `dockerhub` | `ACCESSTOKENS_DOCKERHUB` | `string` |  `""`   | The Dockerhub token, used to avoid the limitations of the DockerHub API _‼️Still Work In Progress_. |
 |    `github` |  `ACCESSTOKENS_GITHUB`   | `string` |  `""`   | The Github token, used to manage images on GitHub (`ghcr.io`) _⚠️Needed for this type of images_.   |
@@ -104,7 +104,7 @@ The access tokens configuration is specified in the `accessTokens` section of `c
 
 The ignore configuration is specified in the `ignore` section of `config.yaml`:
 
-|         Name | Enviromental Variable |   Type   | Default | Description                                                                                                         |
+|         Name | Environmental Variable |   Type   | Default | Description                                                                                                         |
 | -----------: | :-------------------: | :------: | :-----: | :------------------------------------------------------------------------------------------------------------------ |
 | `containers` |  `IGNORE_CONTAINERS`  | `string` |  `""`   | A comma separated list of container to be ignored in the check, or `*` to ignore all containers .                   |
 |    `updates` |   `IGNORE_UPDATES`    | `string` |  `""`   | A comma separated list of container which updates should be ignored in the check, or `*` to ignore all containers . |
@@ -113,7 +113,7 @@ The ignore configuration is specified in the `ignore` section of `config.yaml`:
 
 The ignore configuration is specified in the `logs` section of `config.yaml`:
 
-|    Name | Enviromental Variable |   Type   | Default  | Description                                                                                                     |
+|    Name | Environmental Variable |   Type   | Default  | Description                                                                                                     |
 | ------: | :-------------------: | :------: | :------: | :-------------------------------------------------------------------------------------------------------------- |
 | `level` |     `LOGS_LEVEL`      | `string` | `"info"` | Choose the maximum level of logs to show, in order `error`, `warn`, `info`, `http`, `verbose`, `debug`, `silly` |
 


### PR DESCRIPTION
## Summary
- fix `Environmental Variable` spelling in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840263a07708329af28fd5b04807d5c