### PR TITLE
Add container control buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Create Release](https://github.com/MichelFR/MqDockerUp/actions/workflows/release-checker.yml/badge.svg?branch=main)](https://github.com/MichelFR/MqDockerUp/actions/workflows/release-checker.yml)
 
 # MqDockerUp
-MqDockerUp is a tool that allows you to monitor and update your docker containers using MQTT and homeassistant. It can publish information about your containers, such as name, status, image, ports, etc., to an MQTT broker, and create or update corresponding entities in homeassistant. You can also send commands to start, stop, restart, or remove your containers via MQTT or homeassistant. It even creates update entities in Homeassistant to make it easy to update you running containers. MqDockerUp is easy to set up and configure, and supports multiple platforms and architectures. With MqDockerUp, you can have a unified and convenient way to manage your docker containers from anywhere.
+MqDockerUp is a tool that allows you to monitor and update your docker containers using MQTT and homeassistant. It can publish information about your containers, such as name, status, image, ports, etc., to an MQTT broker, and create or update corresponding entities in homeassistant. You can also send commands to start, stop, pause, unpause, restart, or remove your containers via MQTT or homeassistant. It even creates update entities in Homeassistant to make it easy to update your running containers. MqDockerUp is easy to set up and configure, and supports multiple platforms and architectures. With MqDockerUp, you can have a unified and convenient way to manage your docker containers from anywhere.
 
 
 ## How it works

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,10 @@ client.on('connect', async function () {
 
   client.subscribe(`${config.mqtt.topic}/update`);
   client.subscribe(`${config.mqtt.topic}/restart`);
+  client.subscribe(`${config.mqtt.topic}/start`);
+  client.subscribe(`${config.mqtt.topic}/stop`);
+  client.subscribe(`${config.mqtt.topic}/pause`);
+  client.subscribe(`${config.mqtt.topic}/unpause`);
   client.subscribe(`${config.mqtt.topic}/manualUpdate`);
 });
 
@@ -177,6 +181,86 @@ client.on("message", async (topic: string, message: any) => {
       logger.info(`Got restart message for ${data?.containerId}`);
       await DockerService.restartContainer(data?.containerId);
       logger.info("Restarted container");
+    }
+
+    await checkAndPublishContainerMessages();
+  } else if (topic == `${config.mqtt.topic}/start`) {
+    let data;
+    try {
+      data = JSON.parse(message);
+    } catch (error) {
+      if (error instanceof Error) {
+        logger.warn(`Failed to parse message: ${message}. Error: ${error.message}`);
+      } else {
+        logger.warn(`Failed to parse message: ${message}. Error: ${String(error)}`);
+      }
+      return;
+    }
+
+    if (data?.containerId) {
+      logger.info(`Got start message for ${data?.containerId}`);
+      await DockerService.startContainer(data?.containerId);
+      logger.info("Started container");
+    }
+
+    await checkAndPublishContainerMessages();
+  } else if (topic == `${config.mqtt.topic}/stop`) {
+    let data;
+    try {
+      data = JSON.parse(message);
+    } catch (error) {
+      if (error instanceof Error) {
+        logger.warn(`Failed to parse message: ${message}. Error: ${error.message}`);
+      } else {
+        logger.warn(`Failed to parse message: ${message}. Error: ${String(error)}`);
+      }
+      return;
+    }
+
+    if (data?.containerId) {
+      logger.info(`Got stop message for ${data?.containerId}`);
+      await DockerService.stopContainer(data?.containerId);
+      logger.info("Stopped container");
+    }
+
+    await checkAndPublishContainerMessages();
+  } else if (topic == `${config.mqtt.topic}/pause`) {
+    let data;
+    try {
+      data = JSON.parse(message);
+    } catch (error) {
+      if (error instanceof Error) {
+        logger.warn(`Failed to parse message: ${message}. Error: ${error.message}`);
+      } else {
+        logger.warn(`Failed to parse message: ${message}. Error: ${String(error)}`);
+      }
+      return;
+    }
+
+    if (data?.containerId) {
+      logger.info(`Got pause message for ${data?.containerId}`);
+      await DockerService.pauseContainer(data?.containerId);
+      logger.info("Paused container");
+    }
+
+    await checkAndPublishContainerMessages();
+  } else if (topic == `${config.mqtt.topic}/unpause`) {
+    let data;
+    try {
+      data = JSON.parse(message);
+    } catch (error) {
+      if (error instanceof Error) {
+        logger.warn(`Failed to parse message: ${message}. Error: ${error.message}`);
+      } else {
+        logger.warn(`Failed to parse message: ${message}. Error: ${String(error)}`);
+      }
+      return;
+    }
+
+    if (data?.containerId) {
+      logger.info(`Got unpause message for ${data?.containerId}`);
+      await DockerService.unpauseContainer(data?.containerId);
+      logger.info("Unpaused container");
     }
 
     await checkAndPublishContainerMessages();

--- a/src/services/HomeassistantService.ts
+++ b/src/services/HomeassistantService.ts
@@ -147,6 +147,102 @@ export default class HomeassistantService {
       this.publishMessage(client, topic, payload, {retain: true});
       if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
 
+      // Container manual start
+      topic = `${discoveryPrefix}/button/${topicName}/docker_manual_start/config`;
+      payload = {
+        name: "Start",
+        unique_id: `${image}_${tag}_manual_start`,
+        command_topic: `${config.mqtt.topic}/start`,
+        command_template: JSON.stringify({containerId: container.Id}),
+        availability: {
+          topic: `${config.mqtt.topic}/availability`,
+        },
+        payload_on: "start",
+        device: {
+          manufacturer: "MqDockerUp",
+          model: `${image}:${tag}`,
+          name: deviceName,
+          sw_version: packageJson.version,
+          sa: "Docker",
+          identifiers: [`${image}_${tag}`],
+        },
+        icon: "mdi:play",
+      };
+      this.publishMessage(client, topic, payload, {retain: true});
+      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
+
+      // Container manual stop
+      topic = `${discoveryPrefix}/button/${topicName}/docker_manual_stop/config`;
+      payload = {
+        name: "Stop",
+        unique_id: `${image}_${tag}_manual_stop`,
+        command_topic: `${config.mqtt.topic}/stop`,
+        command_template: JSON.stringify({containerId: container.Id}),
+        availability: {
+          topic: `${config.mqtt.topic}/availability`,
+        },
+        payload_on: "stop",
+        device: {
+          manufacturer: "MqDockerUp",
+          model: `${image}:${tag}`,
+          name: deviceName,
+          sw_version: packageJson.version,
+          sa: "Docker",
+          identifiers: [`${image}_${tag}`],
+        },
+        icon: "mdi:stop",
+      };
+      this.publishMessage(client, topic, payload, {retain: true});
+      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
+
+      // Container manual pause
+      topic = `${discoveryPrefix}/button/${topicName}/docker_manual_pause/config`;
+      payload = {
+        name: "Pause",
+        unique_id: `${image}_${tag}_manual_pause`,
+        command_topic: `${config.mqtt.topic}/pause`,
+        command_template: JSON.stringify({containerId: container.Id}),
+        availability: {
+          topic: `${config.mqtt.topic}/availability`,
+        },
+        payload_on: "pause",
+        device: {
+          manufacturer: "MqDockerUp",
+          model: `${image}:${tag}`,
+          name: deviceName,
+          sw_version: packageJson.version,
+          sa: "Docker",
+          identifiers: [`${image}_${tag}`],
+        },
+        icon: "mdi:pause",
+      };
+      this.publishMessage(client, topic, payload, {retain: true});
+      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
+
+      // Container manual unpause
+      topic = `${discoveryPrefix}/button/${topicName}/docker_manual_unpause/config`;
+      payload = {
+        name: "Unpause",
+        unique_id: `${image}_${tag}_manual_unpause`,
+        command_topic: `${config.mqtt.topic}/unpause`,
+        command_template: JSON.stringify({containerId: container.Id}),
+        availability: {
+          topic: `${config.mqtt.topic}/availability`,
+        },
+        payload_on: "unpause",
+        device: {
+          manufacturer: "MqDockerUp",
+          model: `${image}:${tag}`,
+          name: deviceName,
+          sw_version: packageJson.version,
+          sa: "Docker",
+          identifiers: [`${image}_${tag}`],
+        },
+        icon: "mdi:play-pause",
+      };
+      this.publishMessage(client, topic, payload, {retain: true});
+      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
+
       // Docker Image
       topic = `${discoveryPrefix}/sensor/${topicName}/docker_image/config`;
       payload = this.createPayload("Docker Image", image, tag, "dockerImage", deviceName, null, "mdi:image");


### PR DESCRIPTION
## Summary
- add start/stop/pause/unpause MQTT subscriptions
- handle start/stop/pause/unpause messages
- publish HA button configs for start/stop/pause/unpause
- document new pause/unpause feature
- fix typo in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684027fb67108329b8054c2ebf622863