### PR TITLE
Add container origin sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 # MqDockerUp
 MqDockerUp is a tool that allows you to monitor and update your docker containers using MQTT and homeassistant. It can publish information about your containers, such as name, status, image, ports, etc., to an MQTT broker, and create or update corresponding entities in homeassistant. You can also send commands to start, stop, pause, unpause, restart, or remove your containers via MQTT or homeassistant. It even creates update entities in Homeassistant to make it easy to update your running containers. MqDockerUp is easy to set up and configure, and supports multiple platforms and architectures. With MqDockerUp, you can have a unified and convenient way to manage your docker containers from anywhere.
 
-
 ## How it works
 
 MqDockerUp uses various Docker Registry APIs (DockerHub/GHCR/LSCR) to get information about containers and images. It then makes a request to the Docker Hub API to get information about the latest image tags. If there is a new version, it will publish the change to a specified MQTT broker.

--- a/src/services/DockerService.ts
+++ b/src/services/DockerService.ts
@@ -150,6 +150,19 @@ export default class DockerService {
   }
 
   /**
+   * Determines how the container was created.
+   * Returns "Composer" when compose labels are present otherwise "Docker".
+   *
+   * @param container - Container inspect info
+   */
+  public static getCreatedBy(container: ContainerInspectInfo): string {
+    const labels = container?.Config?.Labels || {};
+    return Object.keys(labels).some((label) => label.startsWith("com.docker.compose"))
+      ? "Composer"
+      : "Docker";
+  }
+
+  /**
    * Gets the source repository for the specified Docker image.
    * @param imageName - The name of the Docker image.
    * @param imageTag - The tag of the Docker image.

--- a/src/services/HomeassistantService.ts
+++ b/src/services/HomeassistantService.ts
@@ -261,6 +261,12 @@ export default class HomeassistantService {
       this.publishMessage(client, topic, payload, {retain: true});
       if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
 
+      // Container Created By
+      topic = `${discoveryPrefix}/sensor/${topicName}/docker_created_by/config`;
+      payload = this.createPayload("Created By", image, tag, "dockerCreatedBy", deviceName, null, "mdi:information");
+      this.publishMessage(client, topic, payload, {retain: true});
+      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
+
 
       if (!IgnoreService.ignoreUpdates(container)) {
         // Container manual update
@@ -607,6 +613,8 @@ export default class HomeassistantService {
 
     let registry = await DockerService.getImageRegistryName(image);
 
+    const createdBy = DockerService.getCreatedBy(container);
+
     const topic = `${config.mqtt.topic}/${formatedImage}`;
     const payload = {
       dockerImage: image,
@@ -621,6 +629,7 @@ export default class HomeassistantService {
       dockerHealth: container.State.Health?.Status || "unknown",
       dockerPorts: dockerPorts,
       dockerRegistry: registry,
+      dockerCreatedBy: createdBy,
     };
     this.publishMessage(client, topic, payload, {retain: true});
   }

--- a/tests/DockerServiceCreatedBy.test.ts
+++ b/tests/DockerServiceCreatedBy.test.ts
@@ -1,0 +1,26 @@
+jest.mock("../src/index", () => ({
+  mqttClient: {
+    publish: jest.fn(),
+    on: jest.fn(),
+    end: jest.fn(),
+  },
+}));
+
+import DockerService from "../src/services/DockerService";
+import { ContainerInspectInfo } from "dockerode";
+
+describe('DockerService.getCreatedBy', () => {
+  test('returns "Composer" when compose labels exist', () => {
+    const container = {
+      Config: { Labels: { 'com.docker.compose.project': 'demo' } }
+    } as unknown as ContainerInspectInfo;
+    expect(DockerService.getCreatedBy(container)).toBe('Composer');
+  });
+
+  test('returns "Docker" when compose labels are missing', () => {
+    const container = {
+      Config: { Labels: { 'random': 'value' } }
+    } as unknown as ContainerInspectInfo;
+    expect(DockerService.getCreatedBy(container)).toBe('Docker');
+  });
+});


### PR DESCRIPTION
## Summary
- expose new `docker_created_by` sensor for each container
- publish the created-by value in container state messages
- detect compose containers via `DockerService.getCreatedBy`
- add unit tests for compose detection
- remove the README addition that described the new sensor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684034a70f94832994828b7a777a06d4