### PR TITLE
Fix container name persistence on update

### DIFF
--- a/src/services/DockerService.ts
+++ b/src/services/DockerService.ts
@@ -273,7 +273,10 @@ export default class DockerService {
               ...info.Config,
               ...info.HostConfig,
               ...info.NetworkSettings,
-              name: info.Name,
+              // info.Name includes a leading slash, which causes the name
+              // to be dropped when recreating the container. Strip it so the
+              // container keeps its original name after an update.
+              name: info.Name.startsWith("/") ? info.Name.substring(1) : info.Name,
               Image: image,
             };
 


### PR DESCRIPTION
## Summary
- preserve the container name when a container is recreated during update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840c18f797c83299dbdc354cf5ebfc8