### PR TITLE
Refactor stability for Docker Image Updates

### DIFF
--- a/src/registry-factory/DockerhubAdapter.ts
+++ b/src/registry-factory/DockerhubAdapter.ts
@@ -34,21 +34,27 @@ export class DockerhubAdapter extends ImageRegistryAdapter {
 
     private getImageUrl(): string {
         const parts = this.image.split("/");
+        let repoPath: string;
 
         if (parts.length === 1) {
-            // If the image name doesn't include a '/', it's an official library image
-            return `${DockerhubAdapter.DOCKER_API_URL}/library/${this.image}/tags/${this.tag}`;
+            // Official Docker library image (e.g., "nginx")
+            repoPath = `library/${parts[0]}`;
+        } else if (parts[0].includes(".") || parts[0].includes(":")) {
+            // Has a registry prefix (e.g., "docker.io/user/image" or "my-registry.com/user/image")
+            repoPath = parts.slice(1).join("/");
         } else {
-            // If the image name includes a '/', it's a user image
-            return `${DockerhubAdapter.DOCKER_API_URL}/${this.image}/tags/${this.tag}`;
+            // No registry prefix, just user/image
+            repoPath = parts.join("/");
         }
+
+        return `${DockerhubAdapter.DOCKER_API_URL}/${repoPath}/tags/${this.tag}`;
     }
     
-    async checkForNewDigest(): Promise<{ newDigest: string; isDifferent: boolean }> {
+    async checkForNewDigest(): Promise<{ newDigest: string; }> {
         try {
             let response = await this.http.get(this.getImageUrl());
             let newDigest = null;
-    
+
             let images = response.data.images;
             if (images && images.length > 0) {
                 newDigest = response.data.digest.split(":")[1];
@@ -56,15 +62,11 @@ export class DockerhubAdapter extends ImageRegistryAdapter {
                 logger.error("No Images found");
                 logger.error(response);
             }
-    
-            const isDifferent = this.oldDigest !== newDigest;
-    
-            return { newDigest, isDifferent };
+
+            return { newDigest};
         } catch (error) {
-            logger.error(`Failed to check for new Dockerhub image digest: ${error}`);
-            logger.warn(`This might be a locally generated image. To prevent similar issues, exclude it from future MqDockerUp checks (see docs)`);
+            logger.error(`Failed to check for new Docker image digest: ${error}`);
             throw error;
         }
     }
-    }
-    
+}

--- a/src/registry-factory/GithubAdapter.ts
+++ b/src/registry-factory/GithubAdapter.ts
@@ -42,24 +42,22 @@ export class GithubAdapter extends ImageRegistryAdapter {
         return `https://${registry}/v2/${user}/${image}/manifests/${this.tag}`;
     }
 
-    async checkForNewDigest(): Promise<{ newDigest: string; isDifferent: boolean }> {
+    async checkForNewDigest(): Promise<{ newDigest: string; }> {
         const accessTokenSet = !!config?.accessTokens?.github;
         if (accessTokenSet) {
             try {
                 this.http.defaults.headers['Accept'] = 'application/vnd.oci.image.index.v1+json';
-                
+
                 const response = await this.http.get(this.getImageUrl());
                 const newDigest = this.removeSHA256Prefix(response.headers['docker-content-digest']);
-    
-                const isDifferent = this.oldDigest !== newDigest;
-    
-                return { newDigest, isDifferent };
+
+                return { newDigest };
             } catch (error) {
-                logger.error(`Failed to check for new github image digest: ${error}`);
+                logger.error(`Failed to check for new Github image digest: ${error}`);
                 throw error;
             }
         }
 
-        return { newDigest: "", isDifferent: true };
+        return { newDigest: "" };
     }
 }

--- a/src/registry-factory/ImageRegistryAdapter.ts
+++ b/src/registry-factory/ImageRegistryAdapter.ts
@@ -26,7 +26,7 @@ export abstract class ImageRegistryAdapter {
         return headers;
     }
 
-    abstract checkForNewDigest(): Promise<{ newDigest: string; isDifferent: boolean }>;
+    abstract checkForNewDigest(): Promise<{ newDigest: string; }>;
 
     protected removeSHA256Prefix(input: string): string {
         const prefix = "sha256:";

--- a/src/registry-factory/LscrAdapter.ts
+++ b/src/registry-factory/LscrAdapter.ts
@@ -34,7 +34,7 @@ export class LscrAdapter extends ImageRegistryAdapter {
         return `${LscrAdapter.DOCKER_API_URL}/${image}/tags?name=${this.tag}`;
     }
 
-    async checkForNewDigest(): Promise<{ newDigest: string; isDifferent: boolean }> {
+    async checkForNewDigest(): Promise<{ newDigest: string; }> {
         try {
             let response = await this.http.get(this.getImageUrl());
             let newDigest = null;
@@ -47,11 +47,9 @@ export class LscrAdapter extends ImageRegistryAdapter {
                 logger.error(response);
             }
 
-            const isDifferent = this.oldDigest !== newDigest;
-
-            return { newDigest, isDifferent };
+            return { newDigest };
         } catch (error) {
-            console.error(`Failed to check for new lscr.io image digest: ${error}`);
+            logger.error(`Failed to check for new lscr.io image digest: ${error}`);
             throw error;
         }
     }

--- a/src/services/DockerService.ts
+++ b/src/services/DockerService.ts
@@ -112,23 +112,17 @@ export default class DockerService {
    * Gets the new docker image digest for the specified image name.
    * @param imageName - The name of the Docker image.
    * @param tag - The tag of the Docker image.
-   * @param oldDigest - The old digest of the Docker image.
    * @returns A promise that resolves to a string containing the new digest.
    */
-  public static async getImageNewDigest(imageName: string, tag: string, oldDigest: string): Promise<string | null> {
+  public static async getImageNewDigest(imageName: string, tag: string): Promise<string | null> {
     try {
       let adapter = ImageRegistryAdapterFactory.getAdapter(imageName, tag);
-      adapter['oldDigest'] = oldDigest;
       let response = await adapter.checkForNewDigest();
 
-      if (response.isDifferent) {
-        return response.newDigest;
-      } else {
-        return oldDigest;
-      }
-
+      return response.newDigest;
+      
     } catch (error: any) {
-      logger.error(imageName, tag, oldDigest);
+      logger.error(imageName, tag);
       logger.error(error);
       return null;
     }


### PR DESCRIPTION
_**This is a small refactor of the Docker image updates. Please review and test, I have made these changes and the Docket image updates are more stable now**_

Firstly, thanks for creating this, having recently migrated my HA to an Intel NUC running Docker, I came across this and found the immediate benefits. 

What I did find however is some stability issues in when Docker image updates might appear. Hopefully the below adds some clarity on the changes I've made in this PR that you may wish to merge in. I've built and tested these changes on my own set up and can confirm they're working.

`docker.io/grafana/grafana              latest      sha256:57bdc141f3f0ac32c2148d0f190cda8406c230f26cf0ec9ea3f33c274b145eb9  dea451b948c6  36 hours ago   740 MB`

The current way of knowing what the currently installed digest is to take the first index in RepoDigests:

`    "RepoDigests": [
               "docker.io/grafana/grafana@sha256:57bdc141f3f0ac32c2148d0f190cda8406c230f26cf0ec9ea3f33c274b145eb9",
             "docker.io/grafana/grafana@sha256:eba36967202bb8fc58404849e58ce10eb12a45cf70370ba483785295f0697da1"
          ],
`

However, what I observed is that there's no guarantee that the installed digest always appears as the first element. As you can see from the eclipse-mosquitto example below:

`docker.io/library/eclipse-mosquitto    latest      sha256:d219d3a72847f3aed6a1d66975972d3b17f86e39e8f6f6b86b4088b879c1a2d6  42292b8c6592  4 weeks ago     11.3 MB

"RepoDigests": [
               "docker.io/library/eclipse-mosquitto@sha256:338276c00dc691eb9c59ac730d874638508073fc1ebe4c4cc957b154a37705bf",
               "docker.io/library/eclipse-mosquitto@sha256:d219d3a72847f3aed6a1d66975972d3b17f86e39e8f6f6b86b4088b879c1a2d6"
          ],
`

What happens in this latter example is that in HA, you will always get told there's a new update. Dockerode doesn't unfortunately provide the Digest itself so what this refactor does is to get the new digest first and then check for the existence of the new digest in the RepoDigest object. This feels a much  more stable way to check whether there's a new digest available for updating from within HA.

This also inadvertently fixes MqDockerUp from a false image update. There's a crash that I currently observe when a container tries to restart after an update because the container ID no longer exists - I'll have a separate PR up for that once I've dug into it. 

Feedback welcomed.
