### PR TITLE
Replace deprecated object_id with default_entity_id

### DIFF
--- a/src/services/HomeassistantService.ts
+++ b/src/services/HomeassistantService.ts
@@ -365,7 +365,7 @@ export default class HomeassistantService {
     const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
 
     return {
-      object_id: prefix ? `${prefix}/${image} ${name}` : `${image} ${name}`,
+      default_entity_id: prefix ? `${prefix}/${image} ${name}` : `${image} ${name}`,
       name: `${name}`,
       unique_id: prefix ? `${prefix}/${image} ${name}` : `${image} ${name}`,
       state_topic: `${config.mqtt.topic}/${formatedImage}`,
@@ -402,7 +402,7 @@ export default class HomeassistantService {
     const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
 
     return {
-      object_id: prefix ? `${prefix}/${image} ${name}` : `${image} ${name}`,
+      default_entity_id: prefix ? `${prefix}/${image} ${name}` : `${image} ${name}`,
       name: `${name}`,
       unique_id: prefix ? `${prefix}/${image} ${name}` : `${image} ${name}`,
       state_topic: `${config.mqtt.topic}/${formatedImage}/update`,


### PR DESCRIPTION
Homeassistant 2025.10 deprecated `object_id` for `default_entity_id`. After updating to 20215.10, the following-like warnings appear.

`2025-10-04 20:45:31.380 WARNING (MainThread) [homeassistant.components.mqtt.entity] The configuration for entity sensor.docker_io_library_influxdb_container_id uses the deprecated option `object_id` to set the default entity id. Replace the `"object_id": "docker.io/library/influxdb Container ID"` option with `"default_entity_id": "sensor.docker.io/library/influxdb Container ID"` in your published discovery configuration to fix this issue, or contact the maintainer of the integration that published this config to fix this.`

This PR addresses this deprecating warning.