### PR TITLE
Scope Home Assistant MQTT discovery by container

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import DockerService from "./services/DockerService";
 import HomeassistantService from "./services/HomeassistantService";
 import DatabaseService from "./services/DatabaseService";
 import TimeService from "./services/TimeService";
+import MqttCommandService, {ContainerCommand, ContainerCommandPayload} from "./services/MqttCommandService";
 import logger from "./services/LoggerService"
 const _ = require('lodash');
 
@@ -128,162 +129,82 @@ client.on('connect', async function () {
     startImageCheckingInterval();
   }
 
-  client.subscribe(`${config.mqtt.topic}/update`);
-  client.subscribe(`${config.mqtt.topic}/restart`);
-  client.subscribe(`${config.mqtt.topic}/start`);
-  client.subscribe(`${config.mqtt.topic}/stop`);
-  client.subscribe(`${config.mqtt.topic}/pause`);
-  client.subscribe(`${config.mqtt.topic}/unpause`);
-  client.subscribe(`${config.mqtt.topic}/manualUpdate`);
+  client.subscribe(MqttCommandService.getCommandSubscription(config.mqtt.topic));
+  for (const legacyCommandTopic of MqttCommandService.getLegacyCommandSubscriptions(config.mqtt.topic)) {
+    client.subscribe(legacyCommandTopic);
+  }
 });
 
 client.on('error', function (err) {
   logger.error('MQTT client connection error: ', err);
 });
-// Update-Handler for the /update message from MQTT
-client.on("message", async (topic: string, message: any) => {
-  if (topic == `${config.mqtt.topic}/update`) {
-    let data;
-    try {
-      data = JSON.parse(message);
-    } catch (error) {
-      if (error instanceof Error) {
-        logger.warn(`Failed to parse message: ${message}. Error: ${error.message}`);
-      } else {
-        logger.warn(`Failed to parse message: ${message}. Error: ${String(error)}`);
-      }
-      return;
-    }
 
-    // Update-Handler for the /update message from MQTT
-    // This is triggered by the Home Assistant button in the UI to update a container
-    if (data?.containerId) {
-      const image = data?.image;
-      logger.info(`Got update message for ${image}`);
-      await DockerService.updateContainer(data?.containerId);
-      logger.info("Updated container");
-      await checkAndPublishContainerMessages();
-      await checkAndPublishImageUpdateMessages();
-    }
-  } else if (topic == `${config.mqtt.topic}/restart`) {
-    let data;
-    try {
-      data = JSON.parse(message);
-    } catch (error) {
-      if (error instanceof Error) {
-        logger.warn(`Failed to parse message: ${message}. Error: ${error.message}`);
-      } else {
-        logger.warn(`Failed to parse message: ${message}. Error: ${String(error)}`);
-      }
-      return;
-    }
+type CommandHandler = (payload: ContainerCommandPayload) => Promise<void>;
 
-    if (data?.containerId) {
-      logger.info(`Got restart message for ${data?.containerId}`);
-      await DockerService.restartContainer(data?.containerId);
-      logger.info("Restarted container");
-    }
+const refreshContainersAfterCommand = async (): Promise<void> => {
+  await checkAndPublishContainerMessages();
+};
 
-    await checkAndPublishContainerMessages();
-  } else if (topic == `${config.mqtt.topic}/start`) {
-    let data;
-    try {
-      data = JSON.parse(message);
-    } catch (error) {
-      if (error instanceof Error) {
-        logger.warn(`Failed to parse message: ${message}. Error: ${error.message}`);
-      } else {
-        logger.warn(`Failed to parse message: ${message}. Error: ${String(error)}`);
-      }
-      return;
-    }
+const commandHandlers: Record<ContainerCommand, CommandHandler> = {
+  update: async (payload) => {
+    logger.info(`Got update message for ${payload.image || payload.containerId}`);
+    await DockerService.updateContainer(payload.containerId);
+    logger.info("Updated container");
+    await refreshContainersAfterCommand();
+    await checkAndPublishImageUpdateMessages();
+  },
+  restart: async (payload) => {
+    logger.info(`Got restart message for ${payload.containerId}`);
+    await DockerService.restartContainer(payload.containerId);
+    logger.info("Restarted container");
+    await refreshContainersAfterCommand();
+  },
+  start: async (payload) => {
+    logger.info(`Got start message for ${payload.containerId}`);
+    await DockerService.startContainer(payload.containerId);
+    logger.info("Started container");
+    await refreshContainersAfterCommand();
+  },
+  stop: async (payload) => {
+    logger.info(`Got stop message for ${payload.containerId}`);
+    await DockerService.stopContainer(payload.containerId);
+    logger.info("Stopped container");
+    await refreshContainersAfterCommand();
+  },
+  pause: async (payload) => {
+    logger.info(`Got pause message for ${payload.containerId}`);
+    await DockerService.pauseContainer(payload.containerId);
+    logger.info("Paused container");
+    await refreshContainersAfterCommand();
+  },
+  unpause: async (payload) => {
+    logger.info(`Got unpause message for ${payload.containerId}`);
+    await DockerService.unpauseContainer(payload.containerId);
+    logger.info("Unpaused container");
+    await refreshContainersAfterCommand();
+  },
+  manualUpdate: async (payload) => {
+    logger.info(`Got manual update message for ${payload.containerId}`);
+    await DockerService.updateContainer(payload.containerId);
+    logger.info("Updated container");
+    await refreshContainersAfterCommand();
+  },
+};
 
-    if (data?.containerId) {
-      logger.info(`Got start message for ${data?.containerId}`);
-      await DockerService.startContainer(data?.containerId);
-      logger.info("Started container");
-    }
+client.on("message", async (topic: string, message: Buffer) => {
+  const commandMessage = MqttCommandService.parseCommandMessage(config.mqtt.topic, topic, message);
 
-    await checkAndPublishContainerMessages();
-  } else if (topic == `${config.mqtt.topic}/stop`) {
-    let data;
-    try {
-      data = JSON.parse(message);
-    } catch (error) {
-      if (error instanceof Error) {
-        logger.warn(`Failed to parse message: ${message}. Error: ${error.message}`);
-      } else {
-        logger.warn(`Failed to parse message: ${message}. Error: ${String(error)}`);
-      }
-      return;
+  if (!commandMessage) {
+    if (MqttCommandService.isCommandTopic(config.mqtt.topic, topic)) {
+      logger.warn(`Ignored invalid MQTT command message on ${topic}`);
     }
+    return;
+  }
 
-    if (data?.containerId) {
-      logger.info(`Got stop message for ${data?.containerId}`);
-      await DockerService.stopContainer(data?.containerId);
-      logger.info("Stopped container");
-    }
-
-    await checkAndPublishContainerMessages();
-  } else if (topic == `${config.mqtt.topic}/pause`) {
-    let data;
-    try {
-      data = JSON.parse(message);
-    } catch (error) {
-      if (error instanceof Error) {
-        logger.warn(`Failed to parse message: ${message}. Error: ${error.message}`);
-      } else {
-        logger.warn(`Failed to parse message: ${message}. Error: ${String(error)}`);
-      }
-      return;
-    }
-
-    if (data?.containerId) {
-      logger.info(`Got pause message for ${data?.containerId}`);
-      await DockerService.pauseContainer(data?.containerId);
-      logger.info("Paused container");
-    }
-
-    await checkAndPublishContainerMessages();
-  } else if (topic == `${config.mqtt.topic}/unpause`) {
-    let data;
-    try {
-      data = JSON.parse(message);
-    } catch (error) {
-      if (error instanceof Error) {
-        logger.warn(`Failed to parse message: ${message}. Error: ${error.message}`);
-      } else {
-        logger.warn(`Failed to parse message: ${message}. Error: ${String(error)}`);
-      }
-      return;
-    }
-
-    if (data?.containerId) {
-      logger.info(`Got unpause message for ${data?.containerId}`);
-      await DockerService.unpauseContainer(data?.containerId);
-      logger.info("Unpaused container");
-    }
-
-    await checkAndPublishContainerMessages();
-  } else if (topic == `${config.mqtt.topic}/manualUpdate`) {
-    let data;
-    try {
-      data = JSON.parse(message);
-    } catch (error) {
-      if (error instanceof Error) {
-        logger.warn(`Failed to parse message: ${message}. Error: ${error.message}`);
-      } else {
-        logger.warn(`Failed to parse message: ${message}. Error: ${String(error)}`);
-      }
-      return;
-    }
-
-    if (data?.containerId) {
-      logger.info(`Got manual update message for ${data?.containerId}`);
-      await DockerService.updateContainer(data?.containerId);
-      logger.info("Updated container");
-      await checkAndPublishContainerMessages();
-    }
+  try {
+    await commandHandlers[commandMessage.command](commandMessage.payload);
+  } catch (error) {
+    logger.error(`Failed to execute command ${commandMessage.command}:`, error);
   }
 });
 

--- a/src/services/DatabaseService.ts
+++ b/src/services/DatabaseService.ts
@@ -9,6 +9,18 @@ export default class DatabaseService {
         logger.info('Connected to the database.');
     });
 
+    private static run(statement: string, params: unknown[] = []): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.db.run(statement, params, (err: Error | null) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
+
     /**
      * Initializes the database.
      * Creates the tables if they don't exist.
@@ -27,7 +39,21 @@ export default class DatabaseService {
                         return;
                     }
 
-                    logger.info('Database initialized successfully');
+                    this.db.run('DELETE FROM topics WHERE id NOT IN (SELECT MIN(id) FROM topics GROUP BY topic, containerId)', (err: Error | null) => {
+                        if (err) {
+                            logger.error(err.message);
+                            return;
+                        }
+
+                        this.db.run('CREATE UNIQUE INDEX IF NOT EXISTS idx_topics_topic_containerId ON topics(topic, containerId)', (err: Error | null) => {
+                            if (err) {
+                                logger.error(err.message);
+                                return;
+                            }
+
+                            logger.info('Database initialized successfully');
+                        });
+                    });
                 });
             });
         });
@@ -41,9 +67,7 @@ export default class DatabaseService {
      * @param tag The container tag
      */
     public static async addContainer(id: string, name: string, image: string, tag: string) {
-        const stmt = this.db.prepare("INSERT OR REPLACE INTO containers(id, name, image, tag) VALUES(?, ?, ?, ?)",);
-        stmt.run(id, name, image, tag);
-        stmt.finalize();
+        await this.run('INSERT OR REPLACE INTO containers(id, name, image, tag) VALUES(?, ?, ?, ?)', [id, name, image, tag]);
     }
 
     /**
@@ -52,9 +76,10 @@ export default class DatabaseService {
      * @param containerId The corresponding container id
      */
     public static async addTopic(topic: string, containerId: string) {
-        const stmt = this.db.prepare("INSERT INTO topics(topic, containerId) VALUES(?, ?)");
-        stmt.run(topic, containerId);
-        stmt.finalize();
+        await this.run(
+            'INSERT OR IGNORE INTO topics(topic, containerId) VALUES(?, ?)',
+            [topic, containerId]
+        );
     }
 
     /**
@@ -88,6 +113,22 @@ export default class DatabaseService {
         });
     }
 
+    public static getTopicsForContainer(containerId: string): Promise<{ topic: string }[]> {
+        return new Promise((resolve, reject) => {
+            this.db.all('SELECT topic FROM topics WHERE containerId = ?', [containerId], (err: any, rows: { topic: string }[]) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(rows);
+                }
+            });
+        });
+    }
+
+    public static async deleteTopic(topic: string, containerId: string) {
+        await this.run('DELETE FROM topics WHERE topic = ? AND containerId = ?', [topic, containerId]);
+    }
+
 
     /**
  * Checks if an container exists in the database.
@@ -111,8 +152,8 @@ export default class DatabaseService {
      * @param id The container id
      */
     public static async deleteContainer(id: string) {
-        this.db.run('DELETE FROM containers WHERE id = ?', [id]);
-        this.db.run('DELETE FROM topics WHERE containerId = ?', [id]);
+        await this.run('DELETE FROM containers WHERE id = ?', [id]);
+        await this.run('DELETE FROM topics WHERE containerId = ?', [id]);
     }
 
 

--- a/src/services/HomeassistantService.ts
+++ b/src/services/HomeassistantService.ts
@@ -2,8 +2,9 @@ import DockerService from "./DockerService";
 import ConfigService from "./ConfigService";
 import DatabaseService from "./DatabaseService";
 import logger from "./LoggerService"
-import {ContainerInspectInfo, ContainerInfo} from "dockerode";
+import {ContainerInspectInfo} from "dockerode";
 import IgnoreService from "./IgnoreService";
+import MqttCommandService, {ContainerCommand} from "./MqttCommandService";
 
 const config = ConfigService.getConfig();
 const packageJson = require("../../package");
@@ -11,7 +12,177 @@ const packageJson = require("../../package");
 const haLegacy = ConfigService.autoParseEnvVariable(config.mqtt?.haLegacy)
 const suggestedArea = config.mqtt?.suggestedArea ?? "Docker";
 
+type DiscoveryDevice = {
+  manufacturer: string;
+  model: string;
+  name: string;
+  sw_version: string;
+  sa: string;
+  identifiers: string[];
+};
+
+type ContainerIdentity = {
+  image: string;
+  tag: string;
+  imageReference: string;
+  digest?: string;
+  containerName: string;
+  topicName: string;
+};
+
+type SensorDiscovery = {
+  key: string;
+  name: string;
+  valueName: string;
+  deviceClass?: string | null;
+  icon: string;
+};
+
+type ButtonDiscovery = {
+  key: string;
+  name: string;
+  command: ContainerCommand;
+  icon: string;
+  payloadPress?: string;
+};
+
+const sensorDiscoveries: SensorDiscovery[] = [
+  {key: "docker_id", name: "Container ID", valueName: "dockerId", deviceClass: null, icon: "mdi:key-variant"},
+  {key: "docker_name", name: "Container Name", valueName: "dockerName", deviceClass: null, icon: "mdi:label"},
+  {key: "docker_status", name: "Container Status", valueName: "dockerStatus", deviceClass: null, icon: "mdi:checkbox-marked-circle"},
+  {key: "docker_uptime", name: "Container Uptime", valueName: "dockerUptime", deviceClass: "timestamp", icon: "mdi:timer-sand"},
+  {key: "docker_created", name: "Container Created", valueName: "dockerCreated", deviceClass: "timestamp", icon: "mdi:calendar-clock"},
+  {key: "docker_restart_count", name: "Container Restart Count", valueName: "dockerRestartCount", deviceClass: null, icon: "mdi:restart"},
+  {key: "docker_restart_policy", name: "Container Restart Policy", valueName: "dockerRestartPolicy", deviceClass: null, icon: "mdi:restart"},
+  {key: "docker_health", name: "Container Health", valueName: "dockerHealth", deviceClass: null, icon: "mdi:heart-pulse"},
+  {key: "docker_ports", name: "Exposed Ports", valueName: "dockerPorts", deviceClass: null, icon: "mdi:lan-connect"},
+  {key: "docker_image", name: "Docker Image", valueName: "dockerImage", deviceClass: null, icon: "mdi:image"},
+  {key: "docker_tag", name: "Docker Tag", valueName: "dockerTag", deviceClass: null, icon: "mdi:tag"},
+  {key: "docker_registry", name: "Docker Registry", valueName: "dockerRegistry", deviceClass: null, icon: "mdi:database"},
+  {key: "docker_created_by", name: "Created By", valueName: "dockerCreatedBy", deviceClass: null, icon: "mdi:information"},
+];
+
+const buttonDiscoveries: ButtonDiscovery[] = [
+  {key: "manual_restart", name: "Manual Restart", command: "restart", icon: "mdi:restart"},
+  {key: "manual_start", name: "Start", command: "start", icon: "mdi:play"},
+  {key: "manual_stop", name: "Stop", command: "stop", icon: "mdi:stop"},
+  {key: "manual_pause", name: "Pause", command: "pause", icon: "mdi:pause"},
+  {key: "manual_unpause", name: "Unpause", command: "unpause", icon: "mdi:play-pause"},
+];
+
 export default class HomeassistantService {
+  private static readonly safeNameRegex = /[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g;
+
+  private static formatSafeName(value: string, replacement: string = "_"): string {
+    return value.replace(this.safeNameRegex, replacement);
+  }
+
+  private static getContainerName(container: ContainerInspectInfo): string {
+    return container.Name.startsWith("/") ? container.Name.substring(1) : container.Name;
+  }
+
+  private static splitImageReference(reference: string | null | undefined): { image: string; tag: string; digest?: string } {
+    if (!reference) {
+      return { image: "unknown", tag: "latest" };
+    }
+
+    const digestIndex = reference.indexOf("@");
+    const imageReference = digestIndex === -1 ? reference : reference.substring(0, digestIndex);
+    const digest = digestIndex === -1 ? undefined : reference.substring(digestIndex + 1);
+    const lastSlashIndex = imageReference.lastIndexOf("/");
+    const lastColonIndex = imageReference.lastIndexOf(":");
+
+    if (lastColonIndex > lastSlashIndex) {
+      return {
+        image: imageReference.substring(0, lastColonIndex),
+        tag: imageReference.substring(lastColonIndex + 1) || "latest",
+        ...(digest ? { digest } : {}),
+      };
+    }
+
+    return {
+      image: imageReference,
+      tag: "latest",
+      ...(digest ? { digest } : {}),
+    };
+  }
+
+  private static getContainerIdentity(container: ContainerInspectInfo): ContainerIdentity {
+    const prefix = config?.main.prefix || "";
+    const imageReference = container.Config?.Image || "unknown";
+    const {image, tag, digest} = this.splitImageReference(imageReference);
+    const containerName = this.getContainerName(container);
+    const formattedContainerName = this.formatSafeName(containerName);
+    const topicName = prefix ? `${prefix}_${formattedContainerName}` : formattedContainerName;
+
+    return {
+      image,
+      tag,
+      imageReference,
+      ...(digest ? { digest } : {}),
+      containerName,
+      topicName,
+    };
+  }
+
+  private static createDevice(imageReference: string, topicName: string): DiscoveryDevice {
+    return {
+      manufacturer: "MqDockerUp",
+      model: imageReference,
+      name: topicName,
+      sw_version: packageJson.version,
+      sa: suggestedArea,
+      identifiers: [topicName],
+    };
+  }
+
+  private static getDiscoveryTopic(component: string, topicName: string, key: string): string {
+    return `${config?.mqtt?.discoveryPrefix}/${component}/${topicName}/${key}/config`;
+  }
+
+  private static async publishDiscoveryMessage(client: any, topic: string, payload: object, containerId: string): Promise<string> {
+    this.publishMessage(client, topic, payload, {retain: true});
+    await DatabaseService.addTopic(topic, containerId);
+    return topic;
+  }
+
+  private static async removeStaleDiscoveryTopics(client: any, containerId: string, currentTopics: string[]) {
+    const currentTopicSet = new Set(currentTopics);
+    const storedTopics = await DatabaseService.getTopicsForContainer(containerId);
+
+    for (const {topic} of storedTopics) {
+      if (currentTopicSet.has(topic)) {
+        continue;
+      }
+
+      this.publishMessage(client, topic, "", {retain: true});
+      await DatabaseService.deleteTopic(topic, containerId);
+    }
+  }
+
+  private static createButtonPayload(
+    name: string,
+    imageReference: string,
+    topicName: string,
+    command: ContainerCommand,
+    containerId: string,
+    icon: string,
+    payloadPress: string = command,
+    uniqueSuffix: string = command
+  ): object {
+    return {
+      name,
+      unique_id: `${topicName}_${uniqueSuffix}`,
+      command_topic: MqttCommandService.getCommandTopic(config.mqtt.topic, topicName, command),
+      command_template: JSON.stringify({containerId, topicName}),
+      availability: {
+        topic: `${config.mqtt.topic}/availability`,
+      },
+      payload_press: payloadPress,
+      device: this.createDevice(imageReference, topicName),
+      icon,
+    };
+  }
 
   /**
    * Published availability message to the MQTT broker to indicate if the service is online or offline
@@ -33,273 +204,63 @@ export default class HomeassistantService {
     const containers = await DockerService.listContainers();
 
     for (const container of containers) {
-      const prefix = config?.main.prefix || "";
-      const image = container.Config.Image.split(":")[0];
-      const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
-      const tag = container.Config.Image.split(":")[1] || "latest";
-      const formatedTag = tag.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "-");
-      const containerName = `${container.Name.substring(1)}`;
-      let containerIsInDb = false;
+      const identity = this.getContainerIdentity(container);
 
-      await DatabaseService.containerExists(container.Id).then((exists) => {
-        containerIsInDb = exists;
-      })
-
-      if (!containerIsInDb) {
-        // Save container info to database
-        logger.info(`Adding container ${containerName} to database`);
-        await DatabaseService.addContainer(container.Id, containerName, image, tag);
+      if (!await DatabaseService.containerExists(container.Id)) {
+        logger.info(`Adding container ${identity.containerName} to database`);
+        await DatabaseService.addContainer(container.Id, identity.containerName, identity.image, identity.tag);
       }
 
-      let topic, payload;
+      const currentTopics: string[] = [];
 
-      let topicName: string = '';
-      let deviceName = containerName;
-
-      if (!prefix) {
-        topicName = `${formatedImage}_${formatedTag}`;
-      } else {
-        topicName = `${prefix}_${formatedImage}_${formatedTag}`;
+      for (const discovery of sensorDiscoveries) {
+        const topic = this.getDiscoveryTopic("sensor", identity.topicName, discovery.key);
+        const payload = this.createPayload(
+          discovery.name,
+          identity.imageReference,
+          discovery.valueName,
+          identity.topicName,
+          discovery.deviceClass,
+          discovery.icon
+        );
+        currentTopics.push(await this.publishDiscoveryMessage(client, topic, payload, container.Id));
       }
 
-      if (!prefix) {
-        deviceName = containerName;
-      } else {
-        deviceName = `${prefix}_${containerName}`;
+      for (const button of buttonDiscoveries) {
+        const topic = this.getDiscoveryTopic("button", identity.topicName, `docker_${button.key}`);
+        const payload = this.createButtonPayload(
+          button.name,
+          identity.imageReference,
+          identity.topicName,
+          button.command,
+          container.Id,
+          button.icon,
+          button.payloadPress ?? button.command,
+          button.key
+        );
+        currentTopics.push(await this.publishDiscoveryMessage(client, topic, payload, container.Id));
       }
-
-      const discoveryPrefix = config?.mqtt?.discoveryPrefix
-
-      // Container Id
-      topic = `${discoveryPrefix}/sensor/${topicName}/docker_id/config`;
-      payload = this.createPayload("Container ID", image, tag, "dockerId", deviceName, null, "mdi:key-variant");
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Container Name
-      topic = `${discoveryPrefix}/sensor/${topicName}/docker_name/config`;
-      payload = this.createPayload("Container Name", image, tag, "dockerName", deviceName, null, "mdi:label");
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Container Status
-      topic = `${discoveryPrefix}/sensor/${topicName}/docker_status/config`;
-      payload = this.createPayload("Container Status", image, tag, "dockerStatus", deviceName, null, "mdi:checkbox-marked-circle");
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Container Uptime
-      topic = `${discoveryPrefix}/sensor/${topicName}/docker_uptime/config`;
-      payload = this.createPayload("Container Uptime", image, tag, "dockerUptime", deviceName, "timestamp", "mdi:timer-sand");
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Container Created
-      topic = `${discoveryPrefix}/sensor/${topicName}/docker_created/config`;
-      payload = this.createPayload("Container Created", image, tag, "dockerCreated", deviceName, "timestamp", "mdi:calendar-clock");
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Container Restart Count
-      topic = `${discoveryPrefix}/sensor/${topicName}/docker_restart_count/config`;
-      payload = this.createPayload("Container Restart Count", image, tag, "dockerRestartCount", deviceName, null, "mdi:restart");
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Container Restart Policy
-      topic = `${discoveryPrefix}/sensor/${topicName}/docker_restart_policy/config`;
-      payload = this.createPayload("Container Restart Policy", image, tag, "dockerRestartPolicy", deviceName, null, "mdi:restart");
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Container Health
-      topic = `${discoveryPrefix}/sensor/${topicName}/docker_health/config`;
-      payload = this.createPayload("Container Health", image, tag, "dockerHealth", deviceName, null, "mdi:heart-pulse");
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Container Ports
-      topic = `${discoveryPrefix}/sensor/${topicName}/docker_ports/config`;
-      payload = this.createPayload("Exposed Ports", image, tag, "dockerPorts", deviceName, null, "mdi:lan-connect");
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Container manual restart
-      topic = `${discoveryPrefix}/button/${topicName}/docker_manual_restart/config`;
-      payload = {
-        name: "Manual Restart",
-        unique_id: `${image}_${tag}_manual_restart`,
-        command_topic: `${config.mqtt.topic}/restart`,
-        command_template: JSON.stringify({containerId: container.Id}),
-        availability: {
-          topic: `${config.mqtt.topic}/availability`,
-        },
-        payload_on: "restart",
-        device: {
-          manufacturer: "MqDockerUp",
-          model: `${image}:${tag}`,
-          name: deviceName,
-          sw_version: packageJson.version,
-          sa: suggestedArea,
-          identifiers: [`${image}_${tag}`],
-        },
-        icon: "mdi:restart",
-      };
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Container manual start
-      topic = `${discoveryPrefix}/button/${topicName}/docker_manual_start/config`;
-      payload = {
-        name: "Start",
-        unique_id: `${image}_${tag}_manual_start`,
-        command_topic: `${config.mqtt.topic}/start`,
-        command_template: JSON.stringify({containerId: container.Id}),
-        availability: {
-          topic: `${config.mqtt.topic}/availability`,
-        },
-        payload_on: "start",
-        device: {
-          manufacturer: "MqDockerUp",
-          model: `${image}:${tag}`,
-          name: deviceName,
-          sw_version: packageJson.version,
-          sa: suggestedArea,
-          identifiers: [`${image}_${tag}`],
-        },
-        icon: "mdi:play",
-      };
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Container manual stop
-      topic = `${discoveryPrefix}/button/${topicName}/docker_manual_stop/config`;
-      payload = {
-        name: "Stop",
-        unique_id: `${image}_${tag}_manual_stop`,
-        command_topic: `${config.mqtt.topic}/stop`,
-        command_template: JSON.stringify({containerId: container.Id}),
-        availability: {
-          topic: `${config.mqtt.topic}/availability`,
-        },
-        payload_on: "stop",
-        device: {
-          manufacturer: "MqDockerUp",
-          model: `${image}:${tag}`,
-          name: deviceName,
-          sw_version: packageJson.version,
-          sa: suggestedArea,
-          identifiers: [`${image}_${tag}`],
-        },
-        icon: "mdi:stop",
-      };
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Container manual pause
-      topic = `${discoveryPrefix}/button/${topicName}/docker_manual_pause/config`;
-      payload = {
-        name: "Pause",
-        unique_id: `${image}_${tag}_manual_pause`,
-        command_topic: `${config.mqtt.topic}/pause`,
-        command_template: JSON.stringify({containerId: container.Id}),
-        availability: {
-          topic: `${config.mqtt.topic}/availability`,
-        },
-        payload_on: "pause",
-        device: {
-          manufacturer: "MqDockerUp",
-          model: `${image}:${tag}`,
-          name: deviceName,
-          sw_version: packageJson.version,
-          sa: suggestedArea,
-          identifiers: [`${image}_${tag}`],
-        },
-        icon: "mdi:pause",
-      };
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Container manual unpause
-      topic = `${discoveryPrefix}/button/${topicName}/docker_manual_unpause/config`;
-      payload = {
-        name: "Unpause",
-        unique_id: `${image}_${tag}_manual_unpause`,
-        command_topic: `${config.mqtt.topic}/unpause`,
-        command_template: JSON.stringify({containerId: container.Id}),
-        availability: {
-          topic: `${config.mqtt.topic}/availability`,
-        },
-        payload_on: "unpause",
-        device: {
-          manufacturer: "MqDockerUp",
-          model: `${image}:${tag}`,
-          name: deviceName,
-          sw_version: packageJson.version,
-          sa: suggestedArea,
-          identifiers: [`${image}_${tag}`],
-        },
-        icon: "mdi:play-pause",
-      };
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Docker Image
-      topic = `${discoveryPrefix}/sensor/${topicName}/docker_image/config`;
-      payload = this.createPayload("Docker Image", image, tag, "dockerImage", deviceName, null, "mdi:image");
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Docker Tag
-      topic = `${discoveryPrefix}/sensor/${topicName}/docker_tag/config`;
-      payload = this.createPayload("Docker Tag", image, tag, "dockerTag", deviceName, null, "mdi:tag");
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Docker Registry
-      topic = `${discoveryPrefix}/sensor/${topicName}/docker_registry/config`;
-      payload = this.createPayload("Docker Registry", image, tag, "dockerRegistry", deviceName, null, "mdi:database");
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
-      // Container Created By
-      topic = `${discoveryPrefix}/sensor/${topicName}/docker_created_by/config`;
-      payload = this.createPayload("Created By", image, tag, "dockerCreatedBy", deviceName, null, "mdi:information");
-      this.publishMessage(client, topic, payload, {retain: true});
-      if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
-
 
       if (!IgnoreService.ignoreUpdates(container)) {
-        // Container manual update
-        topic = `${discoveryPrefix}/button/${topicName}/docker_manual_update/config`;
-        payload = {
-          name: "Manual Update",
-          unique_id: `${image}_${tag}_manual_update`,
-          command_topic: `${config.mqtt.topic}/manualUpdate`,
-          command_template: JSON.stringify({containerId: container.Id}),
-          availability: {
-            topic: `${config.mqtt.topic}/availability`,
-          },
-          payload_on: "update",
-          device: {
-            manufacturer: "MqDockerUp",
-            model: `${image}:${tag}`,
-            name: deviceName,
-            sw_version: packageJson.version,
-            sa: suggestedArea,
-            identifiers: [`${image}_${tag}`],
-          },
-          icon: "mdi:arrow-up-bold-circle",
-        };
-        this.publishMessage(client, topic, payload, {retain: true});
-        if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
+        const manualUpdateTopic = this.getDiscoveryTopic("button", identity.topicName, "docker_manual_update");
+        const manualUpdatePayload = this.createButtonPayload(
+          "Manual Update",
+          identity.imageReference,
+          identity.topicName,
+          "manualUpdate",
+          container.Id,
+          "mdi:arrow-up-bold-circle",
+          "update",
+          "manual_update"
+        );
+        currentTopics.push(await this.publishDiscoveryMessage(client, manualUpdateTopic, manualUpdatePayload, container.Id));
 
-        // Docker Update
-        topic = `${discoveryPrefix}/update/${topicName}/docker_update/config`;
-        payload = this.createUpdatePayload("Update", image, tag, "dockerUpdate", deviceName, container.Id);
-        this.publishMessage(client, topic, payload, {retain: true});
-        if (!containerIsInDb) await DatabaseService.addTopic(topic, container.Id);
+        const updateTopic = this.getDiscoveryTopic("update", identity.topicName, "docker_update");
+        const updatePayload = this.createUpdatePayload("Update", identity.image, identity.imageReference, "dockerUpdate", identity.topicName, container.Id);
+        currentTopics.push(await this.publishDiscoveryMessage(client, updateTopic, updatePayload, container.Id));
       }
+
+      await this.removeStaleDiscoveryTopics(client, container.Id, currentTopics);
     }
   }
 
@@ -346,32 +307,25 @@ export default class HomeassistantService {
       payload = JSON.stringify(payload);
     }
 
-    if (payload == "") {
-      payload = JSON.stringify({})
-    }
-
     client.publish(topic, payload, configObject);
   }
 
   public static createPayload(
     name: string,
-    image: string,
-    tag: string,
+    imageReference: string,
     valueName: string,
-    deviceName: string,
+    topicName: string,
     deviceClass?: string | null,
-    icon: string = "mdi:docker",
-    prefix: string = ""
+    icon: string = "mdi:docker"
   ): object {
-    const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
     const formatedName = name.toLowerCase().replace(/[^a-z0-9_]/g, "_");
-    const defaultEntityId = `sensor.${prefix ? `${prefix}_` : ''}${formatedImage}_${formatedName}`;
+    const defaultEntityId = `sensor.${topicName}_${formatedName}`;
 
     return {
       default_entity_id: defaultEntityId,
       name: `${name}`,
-      unique_id: prefix ? `${prefix}/${image} ${name}` : `${image} ${name}`,
-      state_topic: `${config.mqtt.topic}/${formatedImage}`,
+      unique_id: `${topicName} ${name}`,
+      state_topic: `${config.mqtt.topic}/${topicName}`,
       device_class: deviceClass,
       value_template: `{{ value_json.${valueName} }}`,
       availability:
@@ -379,15 +333,10 @@ export default class HomeassistantService {
           topic: `${config.mqtt.topic}/availability`,
         },
 
-      payload_available: "Online",
-      payload_not_available: "Offline",
+      payload_available: "online",
+      payload_not_available: "offline",
       device: {
-        manufacturer: "MqDockerUp",
-        model: `${image}:${tag}`,
-        name: deviceName,
-        sw_version: packageJson.version,
-        sa: suggestedArea,
-        identifiers: [`${image}_${tag}`],
+        ...this.createDevice(imageReference, topicName),
       },
       icon: icon,
     };
@@ -396,41 +345,34 @@ export default class HomeassistantService {
   public static createUpdatePayload(
     name: string,
     image: string,
-    tag: string,
+    imageReference: string,
     valueName: string,
-    deviceName: string,
-    containerId: any,
-    prefix: string = ""
+    topicName: string,
+    containerId: any
   ): object {
-    const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
     const formatedName = name.toLowerCase().replace(/[^a-z0-9_]/g, "_");
-    const defaultEntityId = `update.${prefix ? `${prefix}_` : ''}${formatedImage}_${formatedName}`;
+    const defaultEntityId = `update.${topicName}_${formatedName}`;
 
     return {
       default_entity_id: defaultEntityId,
       name: `${name}`,
-      unique_id: prefix ? `${prefix}/${image} ${name}` : `${image} ${name}`,
-      state_topic: `${config.mqtt.topic}/${formatedImage}/update`,
+      unique_id: `${topicName} ${name}`,
+      state_topic: `${config.mqtt.topic}/${topicName}/update`,
       device_class: "firmware",
       availability: [
         {
           topic: `${config.mqtt.topic}/availability`,
         },
       ],
-      payload_available: "Online",
-      payload_not_available: "Offline",
+      payload_available: "online",
+      payload_not_available: "offline",
       device: {
-        manufacturer: "MqDockerUp",
-        model: `${image}:${tag}`,
-        name: deviceName,
-        sw_version: packageJson.version,
-        sa: suggestedArea,
-        identifiers: [`${image}_${tag}`],
+        ...this.createDevice(imageReference, topicName),
       },
       icon: "mdi:arrow-up-bold-circle",
       entity_picture: "https://github.com/MichelFR/MqDockerUp/raw/main/assets/logo_200x200.png",
-      payload_install: JSON.stringify({containerId: containerId, image: image}),
-      command_topic: `${config.mqtt.topic}/update`,
+      payload_install: JSON.stringify({containerId: containerId, image: image, topicName}),
+      command_topic: MqttCommandService.getCommandTopic(config.mqtt.topic, topicName, "update"),
     };
   }
 
@@ -455,11 +397,10 @@ export default class HomeassistantService {
       }
     }
 
-    const image = container.Config.Image.split(":")[0];
-    const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
+    const identity = this.getContainerIdentity(container);
 
     // Update entity payload
-    const updateTopic = `${config.mqtt.topic}/${formatedImage}/update`;
+    const updateTopic = `${config.mqtt.topic}/${identity.topicName}/update`;
     let updatePayload: any;
 
     updatePayload = {
@@ -494,11 +435,10 @@ export default class HomeassistantService {
       return;
     }
 
-    const image = container?.Config?.Image?.split(":")[0];
-    const formatedImage = image?.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
+    const identity = this.getContainerIdentity(container);
 
     // Update entity payload
-    const updateTopic = `${config.mqtt.topic}/${formatedImage}/update`;
+    const updateTopic = `${config.mqtt.topic}/${identity.topicName}/update`;
     let updatePayload: any;
 
     updatePayload = {
@@ -528,59 +468,64 @@ export default class HomeassistantService {
       }
     }
 
-    const image = container.Config.Image.split(":")[0];
-    const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
-    const tag = container.Config.Image.split(":")[1] || "latest";
-    const imageInfo = await DockerService.getImageInfo(image + ":" + tag);
+    const identity = this.getContainerIdentity(container);
+    const imageInfo = await DockerService.getImageInfo(identity.imageReference);
     const repoDigests = imageInfo?.RepoDigests || [];
     let currentDigest: string | null = null, newDigest: string | null = null;
 
-    newDigest = await DockerService.getImageNewDigest(image, tag);
+    if (identity.digest) {
+      currentDigest = identity.digest.split(":").pop() || identity.digest;
+      newDigest = currentDigest;
+    } else {
+      newDigest = await DockerService.getImageNewDigest(identity.image, identity.tag);
+    }
 
     if (!newDigest) {
-      logger.warn(`Failed to find new digest for image ${image}:${tag}`);
+      logger.warn(`Failed to find new digest for image ${identity.image}:${identity.tag}`);
     } else {
-      if (repoDigests.length > 0) {
+      if (identity.digest) {
+        logger.info(`Image ${identity.imageReference} is pinned by digest`);
+      } else if (repoDigests.length > 0) {
         if (repoDigests.some(d => d.endsWith(newDigest))) {
           currentDigest = newDigest;
-          logger.info(`Image ${image}:${tag} is up-to-date`);
+          logger.info(`Image ${identity.image}:${identity.tag} is up-to-date`);
         } else {
           currentDigest = repoDigests[0].split(":")[1];
-          logger.info(`New version available for image ${image}:${tag}`);
+          logger.info(`New version available for image ${identity.image}:${identity.tag}`);
         }
       } else {
         currentDigest = "";
-        logger.info(`No existing digests found for image ${image}:${tag}`);
+        logger.info(`No existing digests found for image ${identity.image}:${identity.tag}`);
       }
 
       // Update entity payload
-      const updateTopic = `${config.mqtt.topic}/${formatedImage}/update`;
-      const sourceRepo = await DockerService.getSourceRepo(image, tag);
+      const updateTopic = `${config.mqtt.topic}/${identity.topicName}/update`;
+      const sourceRepo = await DockerService.getSourceRepo(identity.image, identity.tag);
 
       if (sourceRepo) {
         logger.info(`Found source repository: ${sourceRepo}`);
       } else {
-        logger.warn(`Could not find source repository for ${image}`);
+        logger.warn(`Could not find source repository for ${identity.image}`);
       }
 
       let updatePayload: any;
       if (haLegacy) {
         updatePayload = {
-          installed_version: `${tag}: ${currentDigest?.substring(0, 12)}`,
-          latest_version: newDigest ? `${tag}: ${newDigest?.substring(0, 12)}` : null,
+          installed_version: `${identity.tag}: ${currentDigest?.substring(0, 12)}`,
+          latest_version: newDigest ? `${identity.tag}: ${newDigest?.substring(0, 12)}` : null,
           release_notes: null,
           release_url: null,
           entity_picture: null,
-          title: `${image}:${tag}`,
+          title: identity.imageReference,
           progress: 0,
           update: {
             state: currentDigest && newDigest && currentDigest !== newDigest ? "available" : "idle",
-            installed_version: `${tag}: ${currentDigest?.substring(0, 12)}`,
-            latest_version: newDigest ? `${tag}: ${newDigest?.substring(0, 12)}` : null,
+            installed_version: `${identity.tag}: ${currentDigest?.substring(0, 12)}`,
+            latest_version: newDigest ? `${identity.tag}: ${newDigest?.substring(0, 12)}` : null,
             last_check: new Date().toISOString(),
             progress: 0,
             remaining: 0,
-          }
+          },
         };
 
         if (update_percentage !== null && remaining !== null) {
@@ -594,73 +539,65 @@ export default class HomeassistantService {
         }
       } else {
         updatePayload = {
-          installed_version: `${tag}: ${currentDigest?.substring(0, 12)}`,
-          latest_version: newDigest ? `${tag}: ${newDigest?.substring(0, 12)}` : null,
+          installed_version: `${identity.tag}: ${currentDigest?.substring(0, 12)}`,
+          latest_version: newDigest ? `${identity.tag}: ${newDigest?.substring(0, 12)}` : null,
           release_summary: "",
           release_url: `${sourceRepo ? sourceRepo : "https://github.com/MichelFR/MqDockerUp"}/releases`,
           entity_picture: "https://raw.githubusercontent.com/MichelFR/MqDockerUp/refs/heads/main/assets/logo_200x200.png",
-          title: `${image}:${tag}`,
-          in_progress: false,
-          update_percentage: null,
+          title: identity.imageReference,
+          update_percentage: update_percentage,
+          in_progress: update_percentage !== null && remaining !== null,
         };
-
-        if (update_percentage !== null && remaining !== null) {
-          updatePayload.update.update_percentage = update_percentage;
-          updatePayload.update_percentage = update_percentage;
-          updatePayload.update.remaining = remaining;
-        }
-
       }
 
       this.publishMessage(client, updateTopic, updatePayload, {retain: true});
+      if (log) logger.info(`Published update message for ${identity.imageReference}`);
     }
   }
 
   /**
-   * Publish device messages to MQTT
+   * Publish container info to MQTT
    * @param container
    * @param client
    */
   public static async publishContainerMessage(container: ContainerInspectInfo, client: any) {
-    const image = container.Config.Image.split(":")[0];
-    const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
-    const tag = container.Config.Image.split(":")[1] || "latest";
-    const containerName = container.Name.substring(1);
+    const identity = this.getContainerIdentity(container);
 
     let dockerPorts = "";
     if (container.HostConfig.PortBindings) {
-      for (const [key, value] of Object.entries(container.HostConfig.PortBindings)) {
-        if (value && Array.isArray(value) && value.length > 0) {
-          const hostPort = (value[0] as { HostPort: string }).HostPort;
-          dockerPorts += `${key} : ${hostPort}, `;
+      for (const [containerPort, hostPorts] of Object.entries(container.HostConfig.PortBindings)) {
+        if (hostPorts && Array.isArray(hostPorts) && hostPorts.length > 0) {
+          const hostPort = (hostPorts[0] as { HostPort: string }).HostPort;
+          dockerPorts += `${containerPort} : ${hostPort}, `;
         }
       }
-      // Remove the last comma and space if dockerPorts is not empty
       if (dockerPorts.endsWith(", ")) {
         dockerPorts = dockerPorts.slice(0, -2);
       }
     }
 
-    let registry = await DockerService.getImageRegistryName(image);
-
+    const dockerUptime = container.State.StartedAt == "0001-01-01T00:00:00Z" ? "" : container.State.StartedAt
     const createdBy = DockerService.getCreatedBy(container);
 
-    const topic = `${config.mqtt.topic}/${formatedImage}`;
+    const topic = `${config.mqtt.topic}/${identity.topicName}`;
     const payload = {
-      dockerImage: image,
-      dockerTag: tag,
-      dockerName: containerName,
+      dockerImage: identity.image,
+      dockerTag: identity.tag,
       dockerId: container.Id.substring(0, 12),
+      dockerName: identity.containerName,
       dockerStatus: container.State.Status,
-      dockerUptime: container.State.StartedAt,
-      dockerCreated: container.Created,
-      dockerRestartCount: container.RestartCount,
-      dockerRestartPolicy: container?.HostConfig?.RestartPolicy?.Name || "unknown",
       dockerHealth: container.State.Health?.Status || "unknown",
+      dockerRestartCount: container.RestartCount,
+      dockerRestartPolicy: container.HostConfig.RestartPolicy?.Name || "unknown",
       dockerPorts: dockerPorts,
-      dockerRegistry: registry,
+      dockerUptime: dockerUptime,
+      dockerCreated: container.Created,
+      dockerRegistry: await DockerService.getImageRegistryName(identity.image),
       dockerCreatedBy: createdBy,
     };
+
     this.publishMessage(client, topic, payload, {retain: true});
+    logger.info(`Published container message for ${identity.containerName}`);
   }
+
 }

--- a/src/services/MqttCommandService.ts
+++ b/src/services/MqttCommandService.ts
@@ -1,0 +1,165 @@
+export type ContainerCommand =
+  | "update"
+  | "restart"
+  | "start"
+  | "stop"
+  | "pause"
+  | "unpause"
+  | "manualUpdate";
+
+export type ContainerCommandTopic = {
+  containerTopic: string;
+  command: ContainerCommand;
+};
+
+export type ContainerCommandPayload = {
+  containerId: string;
+  image?: string;
+  topicName?: string;
+};
+
+export type ContainerCommandMessage = {
+  command: ContainerCommand;
+  payload: ContainerCommandPayload;
+  containerTopic?: string;
+};
+
+export const containerCommands = [
+  "update",
+  "restart",
+  "start",
+  "stop",
+  "pause",
+  "unpause",
+  "manualUpdate",
+] as const satisfies readonly ContainerCommand[];
+
+const commands: ReadonlySet<string> = new Set(containerCommands);
+
+function isContainerCommand(command: string): command is ContainerCommand {
+  return commands.has(command);
+}
+
+function isCommandPayload(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object";
+}
+
+export default class MqttCommandService {
+  public static getCommandSubscription(topic: string): string {
+    return `${topic}/+/command/+`;
+  }
+
+  public static getLegacyCommandSubscriptions(topic: string): string[] {
+    return containerCommands.map(command => `${topic}/${command}`);
+  }
+
+  public static getCommandTopic(rootTopic: string, containerTopic: string, command: ContainerCommand): string {
+    return `${rootTopic}/${containerTopic}/command/${command}`;
+  }
+
+  public static parseCommandTopic(rootTopic: string, topic: string): ContainerCommandTopic | null {
+    const prefix = `${rootTopic}/`;
+
+    if (!topic.startsWith(prefix)) {
+      return null;
+    }
+
+    const parts = topic.substring(prefix.length).split("/");
+
+    if (parts.length !== 3 || parts[1] !== "command") {
+      return null;
+    }
+
+    const [containerTopic, , command] = parts;
+
+    if (!containerTopic || !isContainerCommand(command)) {
+      return null;
+    }
+
+    return {
+      containerTopic,
+      command,
+    };
+  }
+
+  public static parseLegacyCommandTopic(rootTopic: string, topic: string): ContainerCommand | null {
+    const prefix = `${rootTopic}/`;
+
+    if (!topic.startsWith(prefix)) {
+      return null;
+    }
+
+    const command = topic.substring(prefix.length);
+
+    return isContainerCommand(command) ? command : null;
+  }
+
+  public static parseCommandMessage(rootTopic: string, topic: string, message: Buffer | string): ContainerCommandMessage | null {
+    const payload = this.parseCommandPayload(message);
+
+    if (!payload) {
+      return null;
+    }
+
+    const commandTopic = this.parseCommandTopic(rootTopic, topic);
+
+    if (commandTopic) {
+      if (!this.payloadMatchesCommandTopic(commandTopic, payload)) {
+        return null;
+      }
+
+      return {
+        ...commandTopic,
+        payload,
+      };
+    }
+
+    const legacyCommand = this.parseLegacyCommandTopic(rootTopic, topic);
+
+    if (!legacyCommand) {
+      return null;
+    }
+
+    return {
+      command: legacyCommand,
+      payload,
+    };
+  }
+
+  public static isCommandTopic(rootTopic: string, topic: string): boolean {
+    return this.parseCommandTopic(rootTopic, topic) !== null || this.parseLegacyCommandTopic(rootTopic, topic) !== null;
+  }
+
+  public static payloadMatchesCommandTopic(commandTopic: ContainerCommandTopic, payload: ContainerCommandPayload): boolean {
+    return payload.topicName === commandTopic.containerTopic;
+  }
+
+  public static parseCommandPayload(message: Buffer | string): ContainerCommandPayload | null {
+    let payload: unknown;
+
+    try {
+      payload = JSON.parse(message.toString());
+    } catch {
+      return null;
+    }
+
+    if (!isCommandPayload(payload)) {
+      return null;
+    }
+
+    const containerId = payload.containerId;
+
+    if (typeof containerId !== "string" || !containerId) {
+      return null;
+    }
+
+    const image = payload.image;
+    const topicName = payload.topicName;
+
+    return {
+      containerId,
+      ...(typeof image === "string" && image ? { image } : {}),
+      ...(typeof topicName === "string" && topicName ? { topicName } : {}),
+    };
+  }
+}

--- a/tests/HomeassistantService.test.ts
+++ b/tests/HomeassistantService.test.ts
@@ -1,0 +1,346 @@
+process.env.MAIN_PREFIX = "server";
+
+jest.mock("../src/index", () => ({
+  mqttClient: {
+    publish: jest.fn(),
+    on: jest.fn(),
+    end: jest.fn(),
+  },
+}));
+
+jest.mock("../src/services/DockerService", () => ({
+  __esModule: true,
+  default: {
+    listContainers: jest.fn(),
+    getImageInfo: jest.fn(),
+    getImageNewDigest: jest.fn(),
+    getSourceRepo: jest.fn(),
+  },
+}));
+
+jest.mock("../src/services/DatabaseService", () => ({
+  __esModule: true,
+  default: {
+    containerExists: jest.fn().mockResolvedValue(false),
+    addContainer: jest.fn().mockResolvedValue(undefined),
+    addTopic: jest.fn().mockResolvedValue(undefined),
+    getTopicsForContainer: jest.fn().mockResolvedValue([]),
+    deleteTopic: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock("../src/services/IgnoreService", () => ({
+  __esModule: true,
+  default: {
+    ignoreUpdates: jest.fn().mockReturnValue(false),
+  },
+}));
+
+import { ContainerInspectInfo } from "dockerode";
+import DockerService from "../src/services/DockerService";
+import DatabaseService from "../src/services/DatabaseService";
+import HomeassistantService from "../src/services/HomeassistantService";
+
+describe("HomeassistantService discovery", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("uses container names for Home Assistant identity when containers share an image", async () => {
+    const containers = [
+      {
+        Id: "container-one",
+        Name: "/esphome",
+        Config: { Image: "ghcr.io/esphome/esphome:latest" },
+      },
+      {
+        Id: "container-two",
+        Name: "/esphomefelishas",
+        Config: { Image: "ghcr.io/esphome/esphome:latest" },
+      },
+    ] as unknown as ContainerInspectInfo[];
+
+    (DockerService.listContainers as jest.Mock).mockResolvedValue(containers);
+
+    const client = { publish: jest.fn() };
+    await HomeassistantService.publishConfigMessages(client);
+
+    const messages = client.publish.mock.calls.map(([topic, payload]) => ({
+      topic,
+      payload: JSON.parse(payload),
+    }));
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          topic: "homeassistant/sensor/server_esphome/docker_id/config",
+          payload: expect.objectContaining({
+            unique_id: "server_esphome Container ID",
+            state_topic: "mqdockerup/server_esphome",
+            device: expect.objectContaining({
+              identifiers: ["server_esphome"],
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          topic: "homeassistant/sensor/server_esphomefelishas/docker_id/config",
+          payload: expect.objectContaining({
+            unique_id: "server_esphomefelishas Container ID",
+            state_topic: "mqdockerup/server_esphomefelishas",
+            device: expect.objectContaining({
+              identifiers: ["server_esphomefelishas"],
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          topic: "homeassistant/button/server_esphome/docker_manual_restart/config",
+          payload: expect.objectContaining({
+            command_topic: "mqdockerup/server_esphome/command/restart",
+            command_template: JSON.stringify({ containerId: "container-one", topicName: "server_esphome" }),
+            payload_press: "restart",
+            unique_id: "server_esphome_manual_restart",
+            device: expect.objectContaining({
+              identifiers: ["server_esphome"],
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          topic: "homeassistant/button/server_esphomefelishas/docker_manual_restart/config",
+          payload: expect.objectContaining({
+            command_topic: "mqdockerup/server_esphomefelishas/command/restart",
+            command_template: JSON.stringify({ containerId: "container-two", topicName: "server_esphomefelishas" }),
+            payload_press: "restart",
+            unique_id: "server_esphomefelishas_manual_restart",
+            device: expect.objectContaining({
+              identifiers: ["server_esphomefelishas"],
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          topic: "homeassistant/update/server_esphome/docker_update/config",
+          payload: expect.objectContaining({
+            command_topic: "mqdockerup/server_esphome/command/update",
+            payload_available: "online",
+            payload_not_available: "offline",
+            payload_install: JSON.stringify({ containerId: "container-one", image: "ghcr.io/esphome/esphome", topicName: "server_esphome" }),
+          }),
+        }),
+        expect.objectContaining({
+          topic: "homeassistant/update/server_esphomefelishas/docker_update/config",
+          payload: expect.objectContaining({
+            command_topic: "mqdockerup/server_esphomefelishas/command/update",
+            payload_available: "online",
+            payload_not_available: "offline",
+            payload_install: JSON.stringify({ containerId: "container-two", image: "ghcr.io/esphome/esphome", topicName: "server_esphomefelishas" }),
+          }),
+        }),
+      ])
+    );
+  });
+
+  test("parses image references with registry ports", async () => {
+    const containers = [
+      {
+        Id: "container-one",
+        Name: "/registry-app",
+        Config: { Image: "registry.local:5000/team/app:1.2.3" },
+      },
+    ] as unknown as ContainerInspectInfo[];
+
+    (DockerService.listContainers as jest.Mock).mockResolvedValue(containers);
+
+    const client = { publish: jest.fn() };
+    await HomeassistantService.publishConfigMessages(client);
+
+    const messages = client.publish.mock.calls.map(([topic, payload]) => ({
+      topic,
+      payload: JSON.parse(payload),
+    }));
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          topic: "homeassistant/update/server_registry_app/docker_update/config",
+          payload: expect.objectContaining({
+            command_topic: "mqdockerup/server_registry_app/command/update",
+            payload_install: JSON.stringify({ containerId: "container-one", image: "registry.local:5000/team/app", topicName: "server_registry_app" }),
+            device: expect.objectContaining({
+              model: "registry.local:5000/team/app:1.2.3",
+            }),
+          }),
+        }),
+      ])
+    );
+  });
+
+  test("preserves digest image references in Home Assistant device metadata", async () => {
+    const containers = [
+      {
+        Id: "container-one",
+        Name: "/digest-app",
+        Config: { Image: "ghcr.io/example/app@sha256:abcdef123456" },
+      },
+    ] as unknown as ContainerInspectInfo[];
+
+    (DockerService.listContainers as jest.Mock).mockResolvedValue(containers);
+
+    const client = { publish: jest.fn() };
+    await HomeassistantService.publishConfigMessages(client);
+
+    const messages = client.publish.mock.calls.map(([topic, payload]) => ({
+      topic,
+      payload: JSON.parse(payload),
+    }));
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          topic: "homeassistant/sensor/server_digest_app/docker_id/config",
+          payload: expect.objectContaining({
+            device: expect.objectContaining({
+              model: "ghcr.io/example/app@sha256:abcdef123456",
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          topic: "homeassistant/update/server_digest_app/docker_update/config",
+          payload: expect.objectContaining({
+            payload_install: JSON.stringify({ containerId: "container-one", image: "ghcr.io/example/app", topicName: "server_digest_app" }),
+            device: expect.objectContaining({
+              model: "ghcr.io/example/app@sha256:abcdef123456",
+            }),
+          }),
+        }),
+      ])
+    );
+  });
+
+  test("falls back safely when Docker image references are missing", async () => {
+    const containers = [
+      {
+        Id: "container-one",
+        Name: "/missing-image",
+        Config: {},
+      },
+    ] as unknown as ContainerInspectInfo[];
+
+    (DockerService.listContainers as jest.Mock).mockResolvedValue(containers);
+
+    const client = { publish: jest.fn() };
+    await HomeassistantService.publishConfigMessages(client);
+
+    const messages = client.publish.mock.calls.map(([topic, payload]) => ({
+      topic,
+      payload: JSON.parse(payload),
+    }));
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          topic: "homeassistant/sensor/server_missing_image/docker_image/config",
+          payload: expect.objectContaining({
+            device: expect.objectContaining({
+              model: "unknown",
+            }),
+          }),
+        }),
+      ])
+    );
+  });
+
+  test("uses digest image references when publishing update state", async () => {
+    const container = {
+      Id: "container-one",
+      Name: "/digest-app",
+      Config: { Image: "ghcr.io/example/app@sha256:abcdef123456" },
+    } as unknown as ContainerInspectInfo;
+
+    (DockerService.getImageInfo as jest.Mock).mockResolvedValue({ RepoDigests: [] });
+    (DockerService.getSourceRepo as jest.Mock).mockResolvedValue(null);
+
+    const client = { publish: jest.fn() };
+    await HomeassistantService.publishImageUpdateMessage(container, client);
+
+    expect(DockerService.getImageInfo).toHaveBeenCalledWith("ghcr.io/example/app@sha256:abcdef123456");
+    expect(DockerService.getImageNewDigest).not.toHaveBeenCalled();
+    expect(client.publish).toHaveBeenCalledWith(
+      "mqdockerup/server_digest_app/update",
+      expect.stringContaining('"installed_version":"latest: abcdef123456"'),
+      { retain: true }
+    );
+  });
+
+  test("records discovery topics for containers that already exist", async () => {
+    const containers = [
+      {
+        Id: "existing-container",
+        Name: "/esphome",
+        Config: { Image: "ghcr.io/esphome/esphome:latest" },
+      },
+    ] as unknown as ContainerInspectInfo[];
+
+    (DockerService.listContainers as jest.Mock).mockResolvedValue(containers);
+    (DatabaseService.containerExists as jest.Mock).mockResolvedValue(true);
+
+    const client = { publish: jest.fn() };
+    await HomeassistantService.publishConfigMessages(client);
+
+    expect(DatabaseService.addContainer).not.toHaveBeenCalled();
+    expect(DatabaseService.addTopic).toHaveBeenCalledWith(
+      "homeassistant/sensor/server_esphome/docker_id/config",
+      "existing-container"
+    );
+  });
+
+  test("clears stale discovery topics for existing containers after publishing current topics", async () => {
+    const containers = [
+      {
+        Id: "existing-container",
+        Name: "/esphome",
+        Config: { Image: "ghcr.io/esphome/esphome:latest" },
+      },
+    ] as unknown as ContainerInspectInfo[];
+
+    (DockerService.listContainers as jest.Mock).mockResolvedValue(containers);
+    (DatabaseService.containerExists as jest.Mock).mockResolvedValue(true);
+    (DatabaseService.getTopicsForContainer as jest.Mock).mockResolvedValue([
+      { topic: "homeassistant/sensor/server_esphome/docker_id/config" },
+      { topic: "homeassistant/sensor/server_ghcr_io_esphome_esphome_latest/docker_id/config" },
+    ]);
+
+    const client = { publish: jest.fn() };
+    await HomeassistantService.publishConfigMessages(client);
+
+    expect(client.publish).toHaveBeenCalledWith(
+      "homeassistant/sensor/server_ghcr_io_esphome_esphome_latest/docker_id/config",
+      "",
+      { retain: true }
+    );
+    expect(DatabaseService.deleteTopic).toHaveBeenCalledWith(
+      "homeassistant/sensor/server_ghcr_io_esphome_esphome_latest/docker_id/config",
+      "existing-container"
+    );
+  });
+
+  test("does not clear current update discovery topics during stale topic cleanup", async () => {
+    const containers = [
+      {
+        Id: "existing-container",
+        Name: "/esphome",
+        Config: { Image: "ghcr.io/esphome/esphome:latest" },
+      },
+    ] as unknown as ContainerInspectInfo[];
+
+    (DockerService.listContainers as jest.Mock).mockResolvedValue(containers);
+    (DatabaseService.containerExists as jest.Mock).mockResolvedValue(true);
+    (DatabaseService.getTopicsForContainer as jest.Mock).mockResolvedValue([
+      { topic: "homeassistant/button/server_esphome/docker_manual_update/config" },
+      { topic: "homeassistant/update/server_esphome/docker_update/config" },
+    ]);
+
+    const client = { publish: jest.fn() };
+    await HomeassistantService.publishConfigMessages(client);
+
+    expect(DatabaseService.deleteTopic).not.toHaveBeenCalled();
+  });
+});

--- a/tests/HomeassistantServiceLegacy.test.ts
+++ b/tests/HomeassistantServiceLegacy.test.ts
@@ -1,0 +1,65 @@
+process.env.MAIN_PREFIX = "server";
+process.env.MQTT_HALEGACY = "true";
+
+jest.mock("../src/index", () => ({
+  mqttClient: {
+    publish: jest.fn(),
+    on: jest.fn(),
+    end: jest.fn(),
+  },
+}));
+
+jest.mock("../src/services/DockerService", () => ({
+  __esModule: true,
+  default: {
+    getImageInfo: jest.fn(),
+    getImageNewDigest: jest.fn(),
+    getSourceRepo: jest.fn(),
+  },
+}));
+
+import { ContainerInspectInfo } from "dockerode";
+import DockerService from "../src/services/DockerService";
+import HomeassistantService from "../src/services/HomeassistantService";
+
+describe("HomeassistantService legacy update payload", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("keeps the legacy nested update state while using container topics", async () => {
+    const container = {
+      Id: "container-one",
+      Name: "/esphome",
+      Config: { Image: "ghcr.io/esphome/esphome:latest" },
+    } as unknown as ContainerInspectInfo;
+
+    (DockerService.getImageInfo as jest.Mock).mockResolvedValue({
+      RepoDigests: ["ghcr.io/esphome/esphome@sha256:123456789abcdef"],
+    });
+    (DockerService.getImageNewDigest as jest.Mock).mockResolvedValue("abcdef123456789");
+    (DockerService.getSourceRepo as jest.Mock).mockResolvedValue("https://github.com/esphome/esphome");
+
+    const client = { publish: jest.fn() };
+    await HomeassistantService.publishImageUpdateMessage(container, client, 40, 15, "installing");
+
+    const [topic, payload] = client.publish.mock.calls[0];
+    const parsedPayload = JSON.parse(payload);
+
+    expect(topic).toBe("mqdockerup/server_esphome/update");
+    expect(parsedPayload).toEqual(expect.objectContaining({
+      installed_version: "latest: 123456789abc",
+      latest_version: "latest: abcdef123456",
+      title: "ghcr.io/esphome/esphome:latest",
+      progress: 40,
+      update: expect.objectContaining({
+        state: "installing",
+        installed_version: "latest: 123456789abc",
+        latest_version: "latest: abcdef123456",
+        progress: 40,
+        remaining: 15,
+      }),
+    }));
+    expect(parsedPayload.update.last_check).toEqual(expect.any(String));
+  });
+});

--- a/tests/MqttCommandService.test.ts
+++ b/tests/MqttCommandService.test.ts
@@ -1,0 +1,111 @@
+import MqttCommandService from "../src/services/MqttCommandService";
+
+describe("MqttCommandService", () => {
+  test("builds command subscriptions", () => {
+    expect(MqttCommandService.getCommandSubscription("mqdockerup_server")).toBe("mqdockerup_server/+/command/+");
+    expect(MqttCommandService.getLegacyCommandSubscriptions("mqdockerup_server")).toEqual([
+      "mqdockerup_server/update",
+      "mqdockerup_server/restart",
+      "mqdockerup_server/start",
+      "mqdockerup_server/stop",
+      "mqdockerup_server/pause",
+      "mqdockerup_server/unpause",
+      "mqdockerup_server/manualUpdate",
+    ]);
+  });
+
+  test("builds scoped command topics", () => {
+    expect(MqttCommandService.getCommandTopic("mqdockerup_server", "server_esphome", "restart")).toBe(
+      "mqdockerup_server/server_esphome/command/restart"
+    );
+  });
+
+  test("parses scoped and legacy command topics", () => {
+    expect(MqttCommandService.parseCommandTopic("mqdockerup_server", "mqdockerup_server/server_esphome/command/restart")).toEqual({
+      containerTopic: "server_esphome",
+      command: "restart",
+    });
+    expect(MqttCommandService.parseLegacyCommandTopic("mqdockerup_server", "mqdockerup_server/restart")).toBe("restart");
+  });
+
+  test("rejects unrelated, malformed, and unknown command topics", () => {
+    expect(MqttCommandService.parseCommandTopic("mqdockerup_server", "other/server_esphome/command/restart")).toBeNull();
+    expect(MqttCommandService.parseCommandTopic("mqdockerup_server", "mqdockerup_server/server_esphome/restart")).toBeNull();
+    expect(MqttCommandService.parseCommandTopic("mqdockerup_server", "mqdockerup_server/server_esphome/command/delete")).toBeNull();
+    expect(MqttCommandService.parseCommandTopic("mqdockerup_server", "mqdockerup_server/server_esphome/extra/command/restart")).toBeNull();
+    expect(MqttCommandService.parseLegacyCommandTopic("mqdockerup_server", "mqdockerup_server/delete")).toBeNull();
+    expect(MqttCommandService.parseLegacyCommandTopic("mqdockerup_server", "mqdockerup_server/restart/extra")).toBeNull();
+  });
+
+  test("parses valid command payloads", () => {
+    expect(MqttCommandService.parseCommandPayload(JSON.stringify({
+      containerId: "abc123",
+      image: "ghcr.io/esphome/esphome",
+      topicName: "server_esphome",
+    }))).toEqual({
+      containerId: "abc123",
+      image: "ghcr.io/esphome/esphome",
+      topicName: "server_esphome",
+    });
+  });
+
+  test("rejects invalid command payloads", () => {
+    expect(MqttCommandService.parseCommandPayload("{")).toBeNull();
+    expect(MqttCommandService.parseCommandPayload("{}")).toBeNull();
+    expect(MqttCommandService.parseCommandPayload(JSON.stringify({ containerId: "" }))).toBeNull();
+    expect(MqttCommandService.parseCommandPayload(JSON.stringify({ containerId: 42 }))).toBeNull();
+  });
+});
+
+
+describe("MqttCommandService command messages", () => {
+  test("parses complete command messages", () => {
+    expect(MqttCommandService.parseCommandMessage(
+      "mqdockerup_server",
+      "mqdockerup_server/server_esphome/command/restart",
+      Buffer.from(JSON.stringify({ containerId: "abc123", topicName: "server_esphome" }))
+    )).toEqual({
+      containerTopic: "server_esphome",
+      command: "restart",
+      payload: {
+        containerId: "abc123",
+        topicName: "server_esphome",
+      },
+    });
+  });
+
+  test("identifies command topics", () => {
+    expect(MqttCommandService.isCommandTopic("mqdockerup_server", "mqdockerup_server/server_esphome/command/restart")).toBe(true);
+    expect(MqttCommandService.isCommandTopic("mqdockerup_server", "mqdockerup_server/restart")).toBe(true);
+    expect(MqttCommandService.isCommandTopic("mqdockerup_server", "mqdockerup_server/server_esphome/state")).toBe(false);
+  });
+
+  test("rejects scoped command messages without matching payload topics", () => {
+    expect(MqttCommandService.parseCommandMessage(
+      "mqdockerup_server",
+      "mqdockerup_server/server_esphome/command/restart",
+      JSON.stringify({ containerId: "abc123", topicName: "server_other" })
+    )).toBeNull();
+    expect(MqttCommandService.parseCommandMessage(
+      "mqdockerup_server",
+      "mqdockerup_server/server_esphome/command/restart",
+      JSON.stringify({ containerId: "abc123" })
+    )).toBeNull();
+  });
+});
+
+
+describe("MqttCommandService legacy command messages", () => {
+  test("keeps old flat command topics working", () => {
+    expect(MqttCommandService.parseCommandMessage(
+      "mqdockerup_server",
+      "mqdockerup_server/restart",
+      JSON.stringify({ containerId: "abc123" })
+    )).toEqual({
+      command: "restart",
+      payload: {
+        containerId: "abc123",
+      },
+    });
+  });
+});


### PR DESCRIPTION
This fixes Home Assistant MQTT discovery collisions when multiple containers use the same Docker image/tag.

Previously, discovery topics, unique IDs, device identifiers, state topics, and command topics were derived from the image name/tag. If two containers used the same image, Home Assistant could collapse them into one device/entity set and commands could target the wrong container.

This changes Home Assistant discovery identity to be container-based instead:

- uses the container name, plus the configured prefix, for HA discovery topics, unique IDs, device identifiers, and state topics
- scopes MQTT command topics per container, e.g. `mqdockerup/<container>/command/restart`
- keeps the old flat command topics subscribed for backward compatibility
- records discovery topics for existing containers too, so stale image-based discovery topics can be cleared safely
- preserves exact Docker image references in device/update metadata, including registry ports and digest-pinned images
- keeps HA legacy update payload shape compatible
- updates MQTT button discovery from `payload_on` to `payload_press`
- uses lowercase `online` / `offline` availability payloads to match the published availability state

I refactored the repeated Home Assistant discovery payload generation into shared helpers because the identity change touched every discovery entity type. The goal was to keep the behavior consistent across sensors, buttons, update entities, cleanup, and command routing rather than patching each block separately.

Tests added for:

- duplicate containers sharing the same image/tag
- scoped and legacy MQTT command parsing
- stale discovery topic cleanup
- existing-container discovery topic recording
- registry-port image references
- digest-pinned image references
- legacy HA update payload compatibility
