### PR TITLE
Add logging before trying to inspect container

### DIFF
--- a/src/services/HomeassistantService.ts
+++ b/src/services/HomeassistantService.ts
@@ -528,6 +528,10 @@ export default class HomeassistantService {
       }
     }
 
+    logger.info(
+      `Inspecting container ${container.Name}`
+    );
+    
     const image = container.Config.Image.split(":")[0];
     const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
     const tag = container.Config.Image.split(":")[1] || "latest";


### PR DESCRIPTION
Due to https://github.com/MichelFR/MqDockerUp/issues/258 MqDockerUp crashes when it tries to parse certain image tag formats (eg. Immich tags). This PR adds a log that helps identify the image that caused the crash