### PR TITLE
Add monitor (whitelist) configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ The ignore configuration is specified in the `ignore` section of `config.yaml`:
 | `containers` |  `IGNORE_CONTAINERS`  | `string` |  `""`   | A comma separated list of container to be ignored in the check, or `*` to ignore all containers .                   |
 |    `updates` |   `IGNORE_UPDATES`    | `string` |  `""`   | A comma separated list of container which updates should be ignored in the check, or `*` to ignore all containers . |
 
+### Monitor (Whitelist) Configuration
+
+The monitor configuration is specified in the `monitor` section of `config.yaml`. It is the inverse of the ignore configuration: when set, **only** the listed containers are monitored and every other container is ignored. This is handy when you want to track just a few of your containers instead of denylisting all the others.
+
+Leave a value empty (the default) or set it to `*` to monitor all containers. An explicit ignore (via the `ignore` config or an `mqdockerup.ignore_*` label) always takes precedence over the whitelist. Container names are matched exactly.
+
+|         Name | Environmental Variable |   Type   | Default | Description                                                                                                                       |
+| -----------: | :-------------------: | :------: | :-----: | :-------------------------------------------------------------------------------------------------------------------------------- |
+| `containers` |  `MONITOR_CONTAINERS`  | `string` |  `""`   | A comma separated list of the only containers to be monitored. Empty or `*` monitors all containers.                              |
+|    `updates` |   `MONITOR_UPDATES`    | `string` |  `""`   | A comma separated list of the only containers whose updates should be checked. Empty or `*` checks updates for all containers.    |
+
 ### Logs Configuration
 
 The ignore configuration is specified in the `logs` section of `config.yaml`:
@@ -147,6 +158,9 @@ accessTokens:
 ignore:
   containers: "some,container"
   updates: "other,container"
+monitor:
+  containers: ""
+  updates: ""
 logs:
   level: "info"
 ```
@@ -178,6 +192,8 @@ docker run -d \
   -e ACCESSTOKENS_GITHUB="" \
   -e IGNORE_CONTAINERS="" \
   -e IGNORE_UPDATES="" \
+  -e MONITOR_CONTAINERS="" \
+  -e MONITOR_UPDATES="" \
   -e LOGS_LEVEL="info" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v your/path/data:/app/data/ \
@@ -213,6 +229,8 @@ services:
       ACCESSTOKENS_GITHUB: ""
       IGNORE_CONTAINERS: ""
       IGNORE_UPDATES: ""
+      MONITOR_CONTAINERS: ""
+      MONITOR_UPDATES: ""
       LOGS_LEVEL: "info"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -229,6 +247,8 @@ You can use some of these labels on individual containers to apply to them the e
 | -----------------------------: | :-------: | :------: | :---------------------------------------------------------------------------------------- |
 |  `mqdockerup.ignore_container` | `boolean` | Optional | `true` to ignore the container that have this label, `false` to not ignore                |
 |    `mqdockerup.ignore_updates` | `boolean` | Optional | `true` to ignore the updates of the container that have this label, `false` to not ignore |
+|  `mqdockerup.monitor_container` | `boolean` | Optional | `true` to monitor this container when a whitelist (`MONITOR_CONTAINERS`) is active, regardless of the list |
+|    `mqdockerup.monitor_updates` | `boolean` | Optional | `true` to check this container's updates when a whitelist (`MONITOR_UPDATES`) is active, regardless of the list |
 
 
 ## Screenshots

--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,13 @@ ignore:
   containers: ""
   updates: ""
 
+# Monitor (whitelist) Configuration
+# When set, only the listed containers are monitored/checked for updates.
+# Leave empty (or use "*") to monitor all containers (default behavior).
+monitor:
+  containers: ""
+  updates: ""
+
 # Logging Configuration
 logs:
   level: "info"

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -69,6 +69,10 @@ export default class ConfigService {
           containers: "",
           updates: ""
         },
+        monitor: {
+          containers: "",
+          updates: ""
+        },
         logs: {
           level: "info"
         }
@@ -103,6 +107,16 @@ export default class ConfigService {
         const envKey = process.env[`IGNORE_${key.toUpperCase()}`];
         if (envKey !== undefined) {
           config.ignore[key] = envKey;
+        }
+      }
+
+      // Ensure the section exists so env-only setups (or configs predating
+      // this option) don't crash when a MONITOR_* variable is provided.
+      config.monitor = config.monitor || {};
+      for (const key of Object.keys(defaults.monitor)) {
+        const envKey = process.env[`MONITOR_${key.toUpperCase()}`];
+        if (envKey !== undefined) {
+          config.monitor[key] = envKey;
         }
       }
 

--- a/src/services/IgnoreService.ts
+++ b/src/services/IgnoreService.ts
@@ -26,7 +26,7 @@ export default class IgnoreService {
     // Explicit ignore by label or env list always wins.
     const ignoreContainerByLabel: boolean = ("Labels" in container) && ("mqdockerup.ignore_container" in container.Labels) && container.Labels["mqdockerup.ignore_container"] === "true";
 
-    const containersCommaList = config?.ignore?.containers;
+    const containersCommaList = config?.ignore?.containers ?? "";
     const ignoreContainerByEnv: boolean = container.Names.some(name => containersCommaList.includes(name.replace("/", "")));
 
     if (ignoreContainerByLabel || ignoreContainerByEnv) {
@@ -73,7 +73,7 @@ export default class IgnoreService {
     // Explicit ignore by label or env list always wins.
     const ignoreUpdatesByLabel: boolean = ("Labels" in container.Config) && ("mqdockerup.ignore_updates" in container.Config.Labels) && container.Config.Labels["mqdockerup.ignore_updates"] === "true";
 
-    const containersCommaList = config?.ignore?.updates;
+    const containersCommaList = config?.ignore?.updates ?? "";
     const ignoreUpdatesByEnv = containersCommaList.includes(container.Name.replace("/", ""));
 
     if (ignoreUpdatesByLabel || ignoreUpdatesByEnv) {

--- a/src/services/IgnoreService.ts
+++ b/src/services/IgnoreService.ts
@@ -10,21 +10,40 @@ export default class IgnoreService {
    * Checks if a container should be ignored based on its labels and/or environment variables.
    * A container is ignored if it has the label "mqdockerup.ignore_container" set to "true" and/or its
    * name is included in the list of, comma separated, ignored containers in the configuration file or the environment variable "IGNORE_CONTAINERS" for docker, `*` to apply to all containers.
+   *
+   * When a monitor (whitelist) is configured via `monitor.containers` / "MONITOR_CONTAINERS" or the
+   * label "mqdockerup.monitor_container", only the listed containers are monitored and every other
+   * container is ignored. An explicit ignore (label or list) always wins over the whitelist.
    * @param container The container to check.
    * @returns A boolean indicating if the container should be ignored.
    */
   public static ignoreContainer(container: ContainerInfo) {
-    if (config?.ignore?.containers != "*") {
-      const ignoreContainerByLabel: boolean = ("Labels" in container) && ("mqdockerup.ignore_container" in container.Labels) && container.Labels["mqdockerup.ignore_container"] === "true";
-
-      const containersCommaList = config?.ignore?.containers;
-      const ignoreContainerByEnv: boolean = container.Names.some(name => containersCommaList.includes(name.replace("/", "")));
-
-      return ignoreContainerByLabel || ignoreContainerByEnv;
-
-    } else {
-      return true
+    // Ignore every container.
+    if (config?.ignore?.containers === "*") {
+      return true;
     }
+
+    // Explicit ignore by label or env list always wins.
+    const ignoreContainerByLabel: boolean = ("Labels" in container) && ("mqdockerup.ignore_container" in container.Labels) && container.Labels["mqdockerup.ignore_container"] === "true";
+
+    const containersCommaList = config?.ignore?.containers;
+    const ignoreContainerByEnv: boolean = container.Names.some(name => containersCommaList.includes(name.replace("/", "")));
+
+    if (ignoreContainerByLabel || ignoreContainerByEnv) {
+      return true;
+    }
+
+    // Whitelist: when active, ignore everything that is not explicitly allowed.
+    if (this.isWhitelistActive(config?.monitor?.containers)) {
+      const monitorByLabel: boolean = ("Labels" in container) && ("mqdockerup.monitor_container" in container.Labels) && container.Labels["mqdockerup.monitor_container"] === "true";
+      const monitorByEnv: boolean = this.matchesList(container.Names, config?.monitor?.containers);
+
+      if (!(monitorByLabel || monitorByEnv)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /**
@@ -33,38 +52,93 @@ export default class IgnoreService {
    * name is included in the list of, comma separated, ignored containers in the configuration file or the environment variable "IGNORE_UPDATES" for docker, `*` to apply to all containers.
    * Additionally, MqDockerUp containers are automatically ignored to prevent self-updates.
    *
+   * When a monitor (whitelist) is configured via `monitor.updates` / "MONITOR_UPDATES" or the label
+   * "mqdockerup.monitor_updates", only the listed containers are checked for updates and every other
+   * container is ignored. An explicit ignore (label, list or the MqDockerUp self-ignore) always wins.
+   *
    * @param container The container to check.
    * @returns A boolean indicating if the container should be ignored for updates.
    */
   public static ignoreUpdates(container: ContainerInspectInfo) {
-    if (config?.ignore?.updates != "*") {
-      const ignoreMQDockerUp = this.ignoreMQDockerUpContainers(container);
-
-      const ignoreUpdatesByLabel: boolean = ("Labels" in container.Config) && ("mqdockerup.ignore_updates" in container.Config.Labels) && container.Config.Labels["mqdockerup.ignore_updates"] === "true";
-
-      const containersCommaList = config?.ignore?.updates;
-      const ignoreUpdatesByEnv = containersCommaList.includes(container.Name.replace("/", ""));
-
-      return ignoreUpdatesByLabel || ignoreUpdatesByEnv || ignoreMQDockerUp;
-
-    } else {
-      return true
+    // Ignore updates for every container.
+    if (config?.ignore?.updates === "*") {
+      return true;
     }
+
+    // Always ignore MqDockerUp containers to prevent self-updates.
+    if (this.ignoreMQDockerUpContainers(container)) {
+      return true;
+    }
+
+    // Explicit ignore by label or env list always wins.
+    const ignoreUpdatesByLabel: boolean = ("Labels" in container.Config) && ("mqdockerup.ignore_updates" in container.Config.Labels) && container.Config.Labels["mqdockerup.ignore_updates"] === "true";
+
+    const containersCommaList = config?.ignore?.updates;
+    const ignoreUpdatesByEnv = containersCommaList.includes(container.Name.replace("/", ""));
+
+    if (ignoreUpdatesByLabel || ignoreUpdatesByEnv) {
+      return true;
+    }
+
+    // Whitelist: when active, ignore updates for everything that is not explicitly allowed.
+    if (this.isWhitelistActive(config?.monitor?.updates)) {
+      const monitorByLabel: boolean = ("Labels" in container.Config) && ("mqdockerup.monitor_updates" in container.Config.Labels) && container.Config.Labels["mqdockerup.monitor_updates"] === "true";
+      const monitorByEnv: boolean = this.matchesList([container.Name], config?.monitor?.updates);
+
+      if (!(monitorByLabel || monitorByEnv)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   // Always ignore MqDockerUp containers to prevent self-updates
   private static ignoreMQDockerUpContainers(container: ContainerInspectInfo) {
-    const fullImageName = container.Config.Image;  
-    const lastColon = fullImageName.lastIndexOf(':');  
-    const lastSlash = fullImageName.lastIndexOf('/');  
-    // If a colon exists and it's after the last slash, it's likely a tag.  
-    const imageNameWithoutTag = lastColon > lastSlash ? fullImageName.substring(0, lastColon) : fullImageName;  
+    const fullImageName = container.Config.Image;
+    const lastColon = fullImageName.lastIndexOf(':');
+    const lastSlash = fullImageName.lastIndexOf('/');
+    // If a colon exists and it's after the last slash, it's likely a tag.
+    const imageNameWithoutTag = lastColon > lastSlash ? fullImageName.substring(0, lastColon) : fullImageName;
 
-    const isMqDockerUp = imageNameWithoutTag.toLowerCase().includes("mqdockerup");  
-    if (isMqDockerUp) {  
-      logger.debug(`Ignoring MqDockerUp container updates for ${fullImageName}`);  
-    }  
-    return isMqDockerUp;  
+    const isMqDockerUp = imageNameWithoutTag.toLowerCase().includes("mqdockerup");
+    if (isMqDockerUp) {
+      logger.debug(`Ignoring MqDockerUp container updates for ${fullImageName}`);
+    }
+    return isMqDockerUp;
+  }
+
+  /**
+   * Determines whether a monitor (whitelist) value actually restricts containers.
+   * An empty value or `*` means "monitor all" and therefore disables the whitelist.
+   * @param list The comma separated whitelist value.
+   * @returns A boolean indicating if the whitelist is active.
+   */
+  private static isWhitelistActive(list: string | undefined): boolean {
+    if (typeof list !== "string") {
+      return false;
+    }
+    const trimmed = list.trim();
+    return trimmed !== "" && trimmed !== "*";
+  }
+
+  /**
+   * Performs an exact match of any of the given container names against a comma separated list.
+   * Entries are split on commas, trimmed of whitespace, and matched against names with their
+   * leading "/" stripped.
+   * @param names The container names to check (with or without a leading "/").
+   * @param commaList The comma separated list to match against.
+   * @returns A boolean indicating if any name is contained in the list.
+   */
+  private static matchesList(names: string[], commaList: string | undefined): boolean {
+    if (typeof commaList !== "string") {
+      return false;
+    }
+    const entries = commaList.split(",").map(entry => entry.trim()).filter(Boolean);
+    if (entries.length === 0) {
+      return false;
+    }
+    return names.some(name => entries.includes(name.replace(/^\//, "")));
   }
 
 }

--- a/tests/IgnoreService.test.ts
+++ b/tests/IgnoreService.test.ts
@@ -147,3 +147,42 @@ describe('IgnoreService.ignoreUpdates whitelist (MONITOR_UPDATES)', () => {
     expect(service.ignoreUpdates(labelled)).toBe(false);
   });
 });
+
+describe('IgnoreService with a partially defined config', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  // Loads IgnoreService with a mocked ConfigService so we can inject a config
+  // whose `ignore` section is missing keys (as a shallow-merged partial
+  // config.yaml produces), without touching the real config file.
+  function loadIgnoreServiceWithConfig(configValue: any): typeof IgnoreService {
+    let service: typeof IgnoreService = IgnoreService;
+    jest.isolateModules(() => {
+      jest.doMock("../src/services/ConfigService", () => ({
+        __esModule: true,
+        default: { getConfig: () => configValue },
+      }));
+      service = require("../src/services/IgnoreService").default;
+    });
+    return service;
+  }
+
+  it('does not crash when ignore.updates is undefined', () => {
+    const service = loadIgnoreServiceWithConfig({ ignore: { containers: "" } });
+    expect(() => service.ignoreUpdates(makeInspectInfo('nginx:latest', '/nginx'))).not.toThrow();
+    expect(service.ignoreUpdates(makeInspectInfo('nginx:latest', '/nginx'))).toBe(false);
+  });
+
+  it('does not crash when ignore.containers is undefined', () => {
+    const service = loadIgnoreServiceWithConfig({ ignore: { updates: "" } });
+    expect(() => service.ignoreContainer(makeContainerInfo(['/nginx']))).not.toThrow();
+    expect(service.ignoreContainer(makeContainerInfo(['/nginx']))).toBe(false);
+  });
+
+  it('does not crash when getConfig returns undefined', () => {
+    const service = loadIgnoreServiceWithConfig(undefined);
+    expect(() => service.ignoreContainer(makeContainerInfo(['/nginx']))).not.toThrow();
+    expect(() => service.ignoreUpdates(makeInspectInfo('nginx:latest', '/nginx'))).not.toThrow();
+  });
+});

--- a/tests/IgnoreService.test.ts
+++ b/tests/IgnoreService.test.ts
@@ -7,16 +7,39 @@ jest.mock("../src/index", () => ({
 }));
 
 import IgnoreService from "../src/services/IgnoreService";
-import { ContainerInspectInfo } from "dockerode";
+import { ContainerInfo, ContainerInspectInfo } from "dockerode";
+
+// Builds a minimal ContainerInfo (as returned by listContainers).
+function makeContainerInfo(names: string[], labels: Record<string, string> = {}): ContainerInfo {
+  return { Names: names, Labels: labels } as unknown as ContainerInfo;
+}
+
+// Builds a minimal ContainerInspectInfo (as returned by inspect).
+function makeInspectInfo(image: string, name: string, labels: Record<string, string> = {}): ContainerInspectInfo {
+  return { Config: { Image: image, Labels: labels }, Name: name } as unknown as ContainerInspectInfo;
+}
+
+// Re-imports IgnoreService so it picks up the current environment variables,
+// since the service reads its config once at module load.
+function loadIgnoreServiceWithEnv(env: Record<string, string>): typeof IgnoreService {
+  let service: typeof IgnoreService = IgnoreService;
+  jest.isolateModules(() => {
+    for (const [key, value] of Object.entries(env)) {
+      process.env[key] = value;
+    }
+    service = require("../src/services/IgnoreService").default;
+  });
+  return service;
+}
 
 describe('IgnoreService.ignoreUpdates', () => {
   const cases: Array<[string, string, boolean]> = [
-    ['mqdockerup:latest', '/mqdockerup', true],  
-    ['MqDockerUp:v1.22.1', '/MqDockerUp', true],  
-    ['docker.io/user/mqdockerup:latest', '/custom_name', true],  
-    ['my.registry:5000/mqdockerup:latest', '/mqdockerup', true],  
-    ['nginx:latest', '/nginx', false],  
-    ['my.registry:5000/nginx:latest', '/nginx', false],  
+    ['mqdockerup:latest', '/mqdockerup', true],
+    ['MqDockerUp:v1.22.1', '/MqDockerUp', true],
+    ['docker.io/user/mqdockerup:latest', '/custom_name', true],
+    ['my.registry:5000/mqdockerup:latest', '/mqdockerup', true],
+    ['nginx:latest', '/nginx', false],
+    ['my.registry:5000/nginx:latest', '/nginx', false],
   ];
 
   test.each(cases)('%s %s', (image, name, expected) => {
@@ -29,5 +52,98 @@ describe('IgnoreService.ignoreUpdates', () => {
     };
 
     expect(IgnoreService.ignoreUpdates(container as ContainerInspectInfo)).toBe(expected);
+  });
+});
+
+describe('IgnoreService.ignoreContainer whitelist (MONITOR_CONTAINERS)', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.MONITOR_CONTAINERS;
+    delete process.env.IGNORE_CONTAINERS;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('monitors every container when no whitelist is set (default)', () => {
+    const service = loadIgnoreServiceWithEnv({});
+    expect(service.ignoreContainer(makeContainerInfo(['/nginx']))).toBe(false);
+    expect(service.ignoreContainer(makeContainerInfo(['/anything']))).toBe(false);
+  });
+
+  it('monitors every container when the whitelist is "*"', () => {
+    const service = loadIgnoreServiceWithEnv({ MONITOR_CONTAINERS: '*' });
+    expect(service.ignoreContainer(makeContainerInfo(['/nginx']))).toBe(false);
+  });
+
+  it('only monitors whitelisted containers and ignores the rest', () => {
+    const service = loadIgnoreServiceWithEnv({ MONITOR_CONTAINERS: 'nginx,redis' });
+    expect(service.ignoreContainer(makeContainerInfo(['/nginx']))).toBe(false);
+    expect(service.ignoreContainer(makeContainerInfo(['/redis']))).toBe(false);
+    expect(service.ignoreContainer(makeContainerInfo(['/postgres']))).toBe(true);
+  });
+
+  it('matches whitelist entries exactly (no substring matches)', () => {
+    const service = loadIgnoreServiceWithEnv({ MONITOR_CONTAINERS: 'web' });
+    expect(service.ignoreContainer(makeContainerInfo(['/web']))).toBe(false);
+    expect(service.ignoreContainer(makeContainerInfo(['/webapp']))).toBe(true);
+  });
+
+  it('trims whitespace around whitelist entries', () => {
+    const service = loadIgnoreServiceWithEnv({ MONITOR_CONTAINERS: ' nginx , redis ' });
+    expect(service.ignoreContainer(makeContainerInfo(['/redis']))).toBe(false);
+  });
+
+  it('monitors a container carrying the monitor label even if not in the list', () => {
+    const service = loadIgnoreServiceWithEnv({ MONITOR_CONTAINERS: 'nginx' });
+    const labelled = makeContainerInfo(['/postgres'], { 'mqdockerup.monitor_container': 'true' });
+    expect(service.ignoreContainer(labelled)).toBe(false);
+  });
+
+  it('lets an explicit ignore win over the whitelist', () => {
+    const service = loadIgnoreServiceWithEnv({ MONITOR_CONTAINERS: 'nginx', IGNORE_CONTAINERS: 'nginx' });
+    expect(service.ignoreContainer(makeContainerInfo(['/nginx']))).toBe(true);
+  });
+
+  it('lets the ignore label win over the whitelist', () => {
+    const service = loadIgnoreServiceWithEnv({ MONITOR_CONTAINERS: 'nginx' });
+    const ignored = makeContainerInfo(['/nginx'], { 'mqdockerup.ignore_container': 'true' });
+    expect(service.ignoreContainer(ignored)).toBe(true);
+  });
+});
+
+describe('IgnoreService.ignoreUpdates whitelist (MONITOR_UPDATES)', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.MONITOR_UPDATES;
+    delete process.env.IGNORE_UPDATES;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('only checks updates for whitelisted containers', () => {
+    const service = loadIgnoreServiceWithEnv({ MONITOR_UPDATES: 'nginx' });
+    expect(service.ignoreUpdates(makeInspectInfo('nginx:latest', '/nginx'))).toBe(false);
+    expect(service.ignoreUpdates(makeInspectInfo('redis:latest', '/redis'))).toBe(true);
+  });
+
+  it('always ignores MqDockerUp updates even when whitelisted', () => {
+    const service = loadIgnoreServiceWithEnv({ MONITOR_UPDATES: 'mqdockerup' });
+    expect(service.ignoreUpdates(makeInspectInfo('mqdockerup:latest', '/mqdockerup'))).toBe(true);
+  });
+
+  it('checks updates for a container carrying the monitor_updates label', () => {
+    const service = loadIgnoreServiceWithEnv({ MONITOR_UPDATES: 'nginx' });
+    const labelled = makeInspectInfo('redis:latest', '/redis', { 'mqdockerup.monitor_updates': 'true' });
+    expect(service.ignoreUpdates(labelled)).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #641

## Problem
Today MqDockerUp only has a denylist (`IGNORE_CONTAINERS`). To monitor just a few containers you have to list *everything else* to ignore — and remember to keep that list updated as you add containers.

## Solution
Adds a `monitor` config section that is the inverse of `ignore`. When set, **only** the listed containers are monitored / checked for updates; every other container is ignored.

### New surface
| Config | Env var | Label |
|--------|---------|-------|
| `monitor.containers` | `MONITOR_CONTAINERS` | `mqdockerup.monitor_container` |
| `monitor.updates` | `MONITOR_UPDATES` | `mqdockerup.monitor_updates` |

### Semantics
- Empty `""` (default) or `"*"` → monitor all containers (unchanged behavior — fully backward compatible).
- Non-empty list → only those containers (or those carrying the monitor label) are monitored.
- Precedence: an explicit ignore (label/list) and the automatic MqDockerUp self-ignore always win over the whitelist.
- Whitelist matching is **exact** (comma-split + trim), avoiding substring false positives.

### Notes
- All logic stays in `IgnoreService`; no call-site changes.
- `ConfigService` guards against env-only setups whose `config.yaml` predates this option.
- The existing `ignore` matching is left untouched.

## Tests
- Adds coverage for `ignoreContainer` (previously untested) and the new whitelist paths for both containers and updates.
- Full suite: 45/45 passing; `tsc --noEmit` clean.

## Docs
README updated (new config table, `docker run` / compose examples, labels table) and `config.yaml` gains the `monitor` section.