### PR TITLE
Key MQTT topics and HA identities off the container name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import ConfigService from "./services/ConfigService";
 import DockerService from "./services/DockerService";
 import HomeassistantService from "./services/HomeassistantService";
 import DatabaseService from "./services/DatabaseService";
+import MigrationService from "./services/MigrationService";
 import TimeService from "./services/TimeService";
 import logger from "./services/LoggerService"
 const _ = require('lodash');
@@ -113,6 +114,11 @@ client.on('connect', async function () {
 
   // Publish availability as online
   await HomeassistantService.publishAvailability(client, true);
+
+  // One-off cleanup of legacy (image-based) discovery topics before publishing
+  // the current container-based ones, so upgrading instances don't keep
+  // orphaned Home Assistant entities.
+  MigrationService.runStartupMigrations(client);
 
   if (config?.ignore?.containers == "*") {
     logger.warn('Skipping setup of container checking cause all containers is ignored `ignore.containers="*"`.')

--- a/src/services/DatabaseService.ts
+++ b/src/services/DatabaseService.ts
@@ -13,6 +13,7 @@ export default class DatabaseService {
             logger.info('Connected to the database.');
             this.db.exec('CREATE TABLE IF NOT EXISTS containers(id TEXT PRIMARY KEY, name TEXT, image TEXT, tag TEXT)');
             this.db.exec('CREATE TABLE IF NOT EXISTS topics(id INTEGER PRIMARY KEY AUTOINCREMENT, topic TEXT, containerId TEXT)');
+            this.db.exec('CREATE TABLE IF NOT EXISTS meta(key TEXT PRIMARY KEY, value TEXT)');
             logger.info('Database initialized successfully');
         } catch (err: any) {
             logger.error(err.message);
@@ -41,6 +42,33 @@ export default class DatabaseService {
         this.db
             .prepare("INSERT INTO topics(topic, containerId) VALUES(?, ?)")
             .run(topic, containerId);
+    }
+
+    /**
+     * Gets all stored topics across every container.
+     * @return An array of { topic, containerId } rows.
+     */
+    public static getAllTopics(): any[] {
+        return this.db.prepare('SELECT * FROM topics').all();
+    }
+
+    /**
+     * Reads a value from the key/value meta table (used for one-off migrations).
+     * @param key The meta key
+     * @return The stored value, or undefined if not set
+     */
+    public static getMeta(key: string): string | undefined {
+        const row: any = this.db.prepare('SELECT value FROM meta WHERE key = ?').get(key);
+        return row?.value;
+    }
+
+    /**
+     * Writes a value to the key/value meta table.
+     * @param key The meta key
+     * @param value The value to store
+     */
+    public static setMeta(key: string, value: string) {
+        this.db.prepare('INSERT OR REPLACE INTO meta(key, value) VALUES(?, ?)').run(key, value);
     }
 
     /**

--- a/src/services/HomeassistantService.ts
+++ b/src/services/HomeassistantService.ts
@@ -4,6 +4,7 @@ import DatabaseService from "./DatabaseService";
 import logger from "./LoggerService"
 import {ContainerInspectInfo, ContainerInfo} from "dockerode";
 import IgnoreService from "./IgnoreService";
+import TopicService from "./TopicService";
 
 const config = ConfigService.getConfig();
 const packageJson = require("../../package");
@@ -33,11 +34,8 @@ export default class HomeassistantService {
     const containers = await DockerService.listContainers();
 
     for (const container of containers) {
-      const prefix = config?.main.prefix || "";
       const image = container.Config.Image.split(":")[0];
-      const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
       const tag = container.Config.Image.split(":")[1] || "latest";
-      const formatedTag = tag.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "-");
       const containerName = `${container.Name.substring(1)}`;
       let containerIsInDb = false;
 
@@ -53,20 +51,10 @@ export default class HomeassistantService {
 
       let topic, payload;
 
-      let topicName: string = '';
-      let deviceName = containerName;
-
-      if (!prefix) {
-        topicName = `${formatedImage}_${formatedTag}`;
-      } else {
-        topicName = `${prefix}_${formatedImage}_${formatedTag}`;
-      }
-
-      if (!prefix) {
-        deviceName = containerName;
-      } else {
-        deviceName = `${prefix}_${containerName}`;
-      }
+      // Key discovery topics and entity identities off the (prefixed) container
+      // name so multiple containers of the same image don't overwrite each other.
+      const deviceName = TopicService.getDeviceName(container);
+      const topicName: string = deviceName;
 
       const discoveryPrefix = config?.mqtt?.discoveryPrefix
 
@@ -128,7 +116,7 @@ export default class HomeassistantService {
       topic = `${discoveryPrefix}/button/${topicName}/docker_manual_restart/config`;
       payload = {
         name: "Manual Restart",
-        unique_id: `${image}_${tag}_manual_restart`,
+        unique_id: `${deviceName}_manual_restart`,
         command_topic: `${config.mqtt.topic}/restart`,
         command_template: JSON.stringify({containerId: container.Id}),
         availability: {
@@ -141,7 +129,7 @@ export default class HomeassistantService {
           name: deviceName,
           sw_version: packageJson.version,
           sa: suggestedArea,
-          identifiers: [`${image}_${tag}`],
+          identifiers: [`${deviceName}`],
         },
         icon: "mdi:restart",
       };
@@ -152,7 +140,7 @@ export default class HomeassistantService {
       topic = `${discoveryPrefix}/button/${topicName}/docker_manual_start/config`;
       payload = {
         name: "Start",
-        unique_id: `${image}_${tag}_manual_start`,
+        unique_id: `${deviceName}_manual_start`,
         command_topic: `${config.mqtt.topic}/start`,
         command_template: JSON.stringify({containerId: container.Id}),
         availability: {
@@ -165,7 +153,7 @@ export default class HomeassistantService {
           name: deviceName,
           sw_version: packageJson.version,
           sa: suggestedArea,
-          identifiers: [`${image}_${tag}`],
+          identifiers: [`${deviceName}`],
         },
         icon: "mdi:play",
       };
@@ -176,7 +164,7 @@ export default class HomeassistantService {
       topic = `${discoveryPrefix}/button/${topicName}/docker_manual_stop/config`;
       payload = {
         name: "Stop",
-        unique_id: `${image}_${tag}_manual_stop`,
+        unique_id: `${deviceName}_manual_stop`,
         command_topic: `${config.mqtt.topic}/stop`,
         command_template: JSON.stringify({containerId: container.Id}),
         availability: {
@@ -189,7 +177,7 @@ export default class HomeassistantService {
           name: deviceName,
           sw_version: packageJson.version,
           sa: suggestedArea,
-          identifiers: [`${image}_${tag}`],
+          identifiers: [`${deviceName}`],
         },
         icon: "mdi:stop",
       };
@@ -200,7 +188,7 @@ export default class HomeassistantService {
       topic = `${discoveryPrefix}/button/${topicName}/docker_manual_pause/config`;
       payload = {
         name: "Pause",
-        unique_id: `${image}_${tag}_manual_pause`,
+        unique_id: `${deviceName}_manual_pause`,
         command_topic: `${config.mqtt.topic}/pause`,
         command_template: JSON.stringify({containerId: container.Id}),
         availability: {
@@ -213,7 +201,7 @@ export default class HomeassistantService {
           name: deviceName,
           sw_version: packageJson.version,
           sa: suggestedArea,
-          identifiers: [`${image}_${tag}`],
+          identifiers: [`${deviceName}`],
         },
         icon: "mdi:pause",
       };
@@ -224,7 +212,7 @@ export default class HomeassistantService {
       topic = `${discoveryPrefix}/button/${topicName}/docker_manual_unpause/config`;
       payload = {
         name: "Unpause",
-        unique_id: `${image}_${tag}_manual_unpause`,
+        unique_id: `${deviceName}_manual_unpause`,
         command_topic: `${config.mqtt.topic}/unpause`,
         command_template: JSON.stringify({containerId: container.Id}),
         availability: {
@@ -237,7 +225,7 @@ export default class HomeassistantService {
           name: deviceName,
           sw_version: packageJson.version,
           sa: suggestedArea,
-          identifiers: [`${image}_${tag}`],
+          identifiers: [`${deviceName}`],
         },
         icon: "mdi:play-pause",
       };
@@ -274,7 +262,7 @@ export default class HomeassistantService {
         topic = `${discoveryPrefix}/button/${topicName}/docker_manual_update/config`;
         payload = {
           name: "Manual Update",
-          unique_id: `${image}_${tag}_manual_update`,
+          unique_id: `${deviceName}_manual_update`,
           command_topic: `${config.mqtt.topic}/manualUpdate`,
           command_template: JSON.stringify({containerId: container.Id}),
           availability: {
@@ -287,7 +275,7 @@ export default class HomeassistantService {
             name: deviceName,
             sw_version: packageJson.version,
             sa: suggestedArea,
-            identifiers: [`${image}_${tag}`],
+            identifiers: [`${deviceName}`],
           },
           icon: "mdi:arrow-up-bold-circle",
         };
@@ -363,15 +351,14 @@ export default class HomeassistantService {
     icon: string = "mdi:docker",
     prefix: string = ""
   ): object {
-    const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
     const formatedName = name.toLowerCase().replace(/[^a-z0-9_]/g, "_");
-    const defaultEntityId = `sensor.${prefix ? `${prefix}_` : ''}${formatedImage}_${formatedName}`;
+    const defaultEntityId = `sensor.${TopicService.slugify(deviceName)}_${formatedName}`;
 
     return {
       default_entity_id: defaultEntityId,
       name: `${name}`,
-      unique_id: prefix ? `${prefix}/${image} ${name}` : `${image} ${name}`,
-      state_topic: `${config.mqtt.topic}/${formatedImage}`,
+      unique_id: `${deviceName} ${name}`,
+      state_topic: TopicService.getStateTopic(deviceName),
       device_class: deviceClass,
       value_template: `{{ value_json.${valueName} }}`,
       availability:
@@ -387,7 +374,7 @@ export default class HomeassistantService {
         name: deviceName,
         sw_version: packageJson.version,
         sa: suggestedArea,
-        identifiers: [`${image}_${tag}`],
+        identifiers: [`${deviceName}`],
       },
       icon: icon,
     };
@@ -402,15 +389,14 @@ export default class HomeassistantService {
     containerId: any,
     prefix: string = ""
   ): object {
-    const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
     const formatedName = name.toLowerCase().replace(/[^a-z0-9_]/g, "_");
-    const defaultEntityId = `update.${prefix ? `${prefix}_` : ''}${formatedImage}_${formatedName}`;
+    const defaultEntityId = `update.${TopicService.slugify(deviceName)}_${formatedName}`;
 
     return {
       default_entity_id: defaultEntityId,
       name: `${name}`,
-      unique_id: prefix ? `${prefix}/${image} ${name}` : `${image} ${name}`,
-      state_topic: `${config.mqtt.topic}/${formatedImage}/update`,
+      unique_id: `${deviceName} ${name}`,
+      state_topic: TopicService.getUpdateTopic(deviceName),
       device_class: "firmware",
       availability: [
         {
@@ -425,7 +411,7 @@ export default class HomeassistantService {
         name: deviceName,
         sw_version: packageJson.version,
         sa: suggestedArea,
-        identifiers: [`${image}_${tag}`],
+        identifiers: [`${deviceName}`],
       },
       icon: "mdi:arrow-up-bold-circle",
       entity_picture: "https://github.com/MichelFR/MqDockerUp/raw/main/assets/logo_200x200.png",
@@ -455,11 +441,9 @@ export default class HomeassistantService {
       }
     }
 
-    const image = container.Config.Image.split(":")[0];
-    const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
-
     // Update entity payload
-    const updateTopic = `${config.mqtt.topic}/${formatedImage}/update`;
+    const deviceName = TopicService.getDeviceName(container);
+    const updateTopic = TopicService.getUpdateTopic(deviceName);
     let updatePayload: any;
 
     updatePayload = {
@@ -494,11 +478,9 @@ export default class HomeassistantService {
       return;
     }
 
-    const image = container?.Config?.Image?.split(":")[0];
-    const formatedImage = image?.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
-
     // Update entity payload
-    const updateTopic = `${config.mqtt.topic}/${formatedImage}/update`;
+    const deviceName = TopicService.getDeviceName(container);
+    const updateTopic = TopicService.getUpdateTopic(deviceName);
     let updatePayload: any;
 
     updatePayload = {
@@ -529,7 +511,6 @@ export default class HomeassistantService {
     }
 
     const image = container.Config.Image.split(":")[0];
-    const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
     const tag = container.Config.Image.split(":")[1] || "latest";
     const imageInfo = await DockerService.getImageInfo(image + ":" + tag);
     const repoDigests = imageInfo?.RepoDigests || [];
@@ -554,7 +535,8 @@ export default class HomeassistantService {
       }
 
       // Update entity payload
-      const updateTopic = `${config.mqtt.topic}/${formatedImage}/update`;
+      const deviceName = TopicService.getDeviceName(container);
+      const updateTopic = TopicService.getUpdateTopic(deviceName);
       const sourceRepo = await DockerService.getSourceRepo(image, tag);
 
       if (sourceRepo) {
@@ -623,7 +605,6 @@ export default class HomeassistantService {
    */
   public static async publishContainerMessage(container: ContainerInspectInfo, client: any) {
     const image = container.Config.Image.split(":")[0];
-    const formatedImage = image.replace(/[\/.:;,+*?@^$%#!&"'`|<>{}\[\]()-\s\u0000-\u001F\u007F]/g, "_");
     const tag = container.Config.Image.split(":")[1] || "latest";
     const containerName = container.Name.substring(1);
 
@@ -645,7 +626,8 @@ export default class HomeassistantService {
 
     const createdBy = DockerService.getCreatedBy(container);
 
-    const topic = `${config.mqtt.topic}/${formatedImage}`;
+    const deviceName = TopicService.getDeviceName(container);
+    const topic = TopicService.getStateTopic(deviceName);
     const payload = {
       dockerImage: image,
       dockerTag: tag,

--- a/src/services/HomeassistantService.ts
+++ b/src/services/HomeassistantService.ts
@@ -348,8 +348,7 @@ export default class HomeassistantService {
     valueName: string,
     deviceName: string,
     deviceClass?: string | null,
-    icon: string = "mdi:docker",
-    prefix: string = ""
+    icon: string = "mdi:docker"
   ): object {
     const formatedName = name.toLowerCase().replace(/[^a-z0-9_]/g, "_");
     const defaultEntityId = `sensor.${TopicService.slugify(deviceName)}_${formatedName}`;
@@ -386,8 +385,7 @@ export default class HomeassistantService {
     tag: string,
     valueName: string,
     deviceName: string,
-    containerId: any,
-    prefix: string = ""
+    containerId: any
   ): object {
     const formatedName = name.toLowerCase().replace(/[^a-z0-9_]/g, "_");
     const defaultEntityId = `update.${TopicService.slugify(deviceName)}_${formatedName}`;

--- a/src/services/MigrationService.ts
+++ b/src/services/MigrationService.ts
@@ -1,0 +1,65 @@
+import DatabaseService from "./DatabaseService";
+import logger from "./LoggerService";
+
+const LEGACY_TOPIC_CLEANUP_KEY = "legacyContainerTopicCleanup";
+
+/**
+ * Runs one-off data/MQTT migrations on startup.
+ */
+export default class MigrationService {
+
+  /**
+   * Runs all pending startup migrations. Safe to call on every startup; each
+   * migration guards itself so it only runs once.
+   * @param client The connected MQTT client.
+   */
+  public static runStartupMigrations(client: any): void {
+    try {
+      this.clearLegacyDiscoveryTopics(client);
+    } catch (err: any) {
+      logger.error(`Startup migration failed: ${err?.message || err}`);
+    }
+  }
+
+  /**
+   * One-time cleanup for instances upgrading from versions that keyed MQTT
+   * discovery topics off the image instead of the container name. Every
+   * previously-published (retained) discovery topic — persisted in the database
+   * when it was first published — is cleared with an empty payload so Home
+   * Assistant removes the old entity and the broker drops the retained message.
+   * The stored containers/topics are then dropped so the current scheme
+   * re-registers them keyed off the container name. Guarded by a meta flag so it
+   * only runs once.
+   * @param client The connected MQTT client.
+   */
+  private static clearLegacyDiscoveryTopics(client: any): void {
+    if (DatabaseService.getMeta(LEGACY_TOPIC_CLEANUP_KEY)) {
+      return;
+    }
+
+    const topics = DatabaseService.getAllTopics();
+    for (const { topic } of topics) {
+      // An empty, retained payload is what removes the entity and clears the
+      // retained discovery message. (publishMessage would turn "" into "{}",
+      // which would not remove anything, so publish directly here.)
+      client.publish(topic, "", { retain: true, qos: 0 });
+    }
+
+    // Drop the stored containers/topics so the current scheme re-registers them
+    // (and stores the new topic names for future removals).
+    DatabaseService.getContainers((err: any, rows: any) => {
+      if (err || !rows) {
+        return;
+      }
+      for (const container of rows) {
+        DatabaseService.deleteContainer(container.id);
+      }
+    });
+
+    DatabaseService.setMeta(LEGACY_TOPIC_CLEANUP_KEY, "done");
+
+    if (topics.length > 0) {
+      logger.info(`Migration: cleared ${topics.length} legacy discovery topic(s); entities will be republished under the container-name scheme.`);
+    }
+  }
+}

--- a/src/services/TopicService.ts
+++ b/src/services/TopicService.ts
@@ -1,0 +1,51 @@
+import ConfigService from "./ConfigService";
+
+const config = ConfigService.getConfig();
+
+/**
+ * Central place for building the per-container MQTT topics and Home Assistant
+ * identifiers. Keeping this in one service avoids duplicating the naming logic
+ * across HomeassistantService and guarantees that the discovery `state_topic`
+ * and the topic the state is actually published to always match.
+ */
+export default class TopicService {
+
+  /**
+   * The per-container device name (optionally prefixed) used for MQTT topics and
+   * Home Assistant entity identities. Basing it on the container name — instead
+   * of the image — means multiple containers of the same image, and containers
+   * with the same name on different hosts (distinguished via the prefix), no
+   * longer overwrite each other.
+   * @param container The inspected container.
+   * @returns The device name, e.g. "nginx" or "host1_nginx".
+   */
+  public static getDeviceName(container: any): string {
+    const prefix = config?.main?.prefix || "";
+    const containerName = container.Name.substring(1);
+    return prefix ? `${prefix}_${containerName}` : containerName;
+  }
+
+  /**
+   * The base MQTT state topic for a device, e.g. "mqdockerup/host1_nginx".
+   * @param deviceName The device name from {@link getDeviceName}.
+   */
+  public static getStateTopic(deviceName: string): string {
+    return `${config.mqtt.topic}/${deviceName}`;
+  }
+
+  /**
+   * The MQTT update topic for a device, e.g. "mqdockerup/host1_nginx/update".
+   * @param deviceName The device name from {@link getDeviceName}.
+   */
+  public static getUpdateTopic(deviceName: string): string {
+    return `${this.getStateTopic(deviceName)}/update`;
+  }
+
+  /**
+   * Slugifies a value into a string safe for use in Home Assistant entity ids.
+   * @param value The value to slugify.
+   */
+  public static slugify(value: string): string {
+    return value.toLowerCase().replace(/[^a-z0-9_]/g, "_");
+  }
+}

--- a/src/services/TopicService.ts
+++ b/src/services/TopicService.ts
@@ -21,8 +21,8 @@ export default class TopicService {
    */
   public static getDeviceName(container: any): string {
     const prefix = config?.main?.prefix || "";
-    const containerName = container.Name.substring(1);
-    return prefix ? `${prefix}_${containerName}` : containerName;
+    const containerName = container?.Name ? container.Name.substring(1) : "";
+    return prefix && containerName ? `${prefix}_${containerName}` : containerName;
   }
 
   /**
@@ -30,7 +30,7 @@ export default class TopicService {
    * @param deviceName The device name from {@link getDeviceName}.
    */
   public static getStateTopic(deviceName: string): string {
-    return `${config.mqtt.topic}/${deviceName}`;
+    return `${config?.mqtt?.topic || "mqdockerup"}/${deviceName}`;
   }
 
   /**

--- a/tests/MigrationService.test.ts
+++ b/tests/MigrationService.test.ts
@@ -1,0 +1,69 @@
+const mockDb = {
+  getMeta: jest.fn(),
+  getAllTopics: jest.fn(),
+  getContainers: jest.fn(),
+  deleteContainer: jest.fn(),
+  setMeta: jest.fn(),
+};
+
+jest.mock("../src/services/DatabaseService", () => ({
+  __esModule: true,
+  default: mockDb,
+}));
+
+import MigrationService from "../src/services/MigrationService";
+
+const FLAG = "legacyContainerTopicCleanup";
+
+function makeClient() {
+  return { publish: jest.fn() };
+}
+
+describe("MigrationService legacy topic cleanup", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("clears stored topics, wipes containers and sets the flag on first run", () => {
+    mockDb.getMeta.mockReturnValue(undefined);
+    mockDb.getAllTopics.mockReturnValue([
+      { topic: "homeassistant/sensor/nginx_latest/docker_id/config", containerId: "c1" },
+      { topic: "homeassistant/button/nginx_latest/docker_manual_restart/config", containerId: "c1" },
+    ]);
+    mockDb.getContainers.mockImplementation((cb: Function) => cb(null, [{ id: "c1" }]));
+    const client = makeClient();
+
+    MigrationService.runStartupMigrations(client);
+
+    // Empty + retained payload to each stored topic (removes the HA entity).
+    expect(client.publish).toHaveBeenCalledTimes(2);
+    expect(client.publish).toHaveBeenCalledWith(
+      "homeassistant/sensor/nginx_latest/docker_id/config",
+      "",
+      { retain: true, qos: 0 }
+    );
+    expect(mockDb.deleteContainer).toHaveBeenCalledWith("c1");
+    expect(mockDb.setMeta).toHaveBeenCalledWith(FLAG, "done");
+  });
+
+  it("does nothing when the migration already ran", () => {
+    mockDb.getMeta.mockReturnValue("done");
+    const client = makeClient();
+
+    MigrationService.runStartupMigrations(client);
+
+    expect(client.publish).not.toHaveBeenCalled();
+    expect(mockDb.getAllTopics).not.toHaveBeenCalled();
+    expect(mockDb.setMeta).not.toHaveBeenCalled();
+  });
+
+  it("marks done without publishing on a fresh install with no stored topics", () => {
+    mockDb.getMeta.mockReturnValue(undefined);
+    mockDb.getAllTopics.mockReturnValue([]);
+    mockDb.getContainers.mockImplementation((cb: Function) => cb(null, []));
+    const client = makeClient();
+
+    MigrationService.runStartupMigrations(client);
+
+    expect(client.publish).not.toHaveBeenCalled();
+    expect(mockDb.setMeta).toHaveBeenCalledWith(FLAG, "done");
+  });
+});


### PR DESCRIPTION
Multiple containers running the same image (and same-named containers on different hosts via the prefix) previously shared image-based MQTT topics and Home Assistant unique_ids / identifiers, so they overwrote each other and only one container showed up.

Add a TopicService that centralizes the per-container device name, state topic, update topic and entity-id slug, and route HomeassistantService through it. Discovery state_topic and the topic the state is published to now always match because they come from the same method. This also removes the duplicated formatedImage logic that was repeated across the service.

Re-implements PR #424 by @libots on top of current main.