### PR TITLE
Replace Digest Hash with version in HA Update message

### DIFF
--- a/src/registry-factory/DockerhubAdapter.ts
+++ b/src/registry-factory/DockerhubAdapter.ts
@@ -81,7 +81,6 @@ export class DockerhubAdapter extends ImageRegistryAdapter {
     /**
      * Resolves the org.opencontainers.image.version label of the tracked tag
      * by fetching its manifest and config blob from Docker Hub's registry API
-     * (no image pull needed).
      */
     async getVersionLabel(): Promise<string | null> {
         try {
@@ -95,18 +94,7 @@ export class DockerhubAdapter extends ImageRegistryAdapter {
                 headers: { ...headers, Accept: 'application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' },
             });
 
-            // Single-arch images return the manifest (with a "config" descriptor) directly;
-            // multi-arch images return an index, so resolve one platform's manifest first.
             let configDigest = indexResponse.data?.config?.digest;
-            if (!configDigest) {
-                const platformDigest = indexResponse.data?.manifests?.[0]?.digest;
-                if (!platformDigest) return null;
-
-                const manifestResponse = await this.http.get(`${DockerhubAdapter.REGISTRY_API_URL}/${repoPath}/manifests/${platformDigest}`, {
-                    headers: { ...headers, Accept: 'application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' },
-                });
-                configDigest = manifestResponse.data?.config?.digest;
-            }
             if (!configDigest) return null;
 
             const configResponse = await this.http.get(`${DockerhubAdapter.REGISTRY_API_URL}/${repoPath}/blobs/${configDigest}`, { headers });

--- a/src/registry-factory/DockerhubAdapter.ts
+++ b/src/registry-factory/DockerhubAdapter.ts
@@ -19,13 +19,13 @@ export class DockerhubAdapter extends ImageRegistryAdapter {
         try {
             const url = new URL(`https://${image}`);
             const host = url.hostname;
-    
+
             // check if the host is exactly 'docker.io'
             const isDockerIo = host === 'docker.io';
-    
+
             const parts = image.split("/");
             const isDefaultDocker = parts.length === 1 || (parts.length === 2 && !parts[0].includes("."));
-    
+
             return isDockerIo || isDefaultDocker;
         } catch (error) {
             // if the image string is not a valid URL, it's not a Docker image
@@ -50,7 +50,7 @@ export class DockerhubAdapter extends ImageRegistryAdapter {
 
         return `${DockerhubAdapter.DOCKER_API_URL}/${repoPath}/tags/${this.tag}`;
     }
-    
+
     async checkForNewDigest(): Promise<{ newDigest: string; }> {
         try {
             let response = await this.http.get(this.getImageUrl());
@@ -91,7 +91,7 @@ export class DockerhubAdapter extends ImageRegistryAdapter {
             const headers = { Authorization: `Bearer ${tokenResponse.data.token}` };
 
             const indexResponse = await this.http.get(`${DockerhubAdapter.REGISTRY_API_URL}/${repoPath}/manifests/${this.tag}`, {
-                headers: { ...headers, Accept: 'application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' },
+                headers: { ...headers, Accept: 'application/json' },
             });
 
             let configDigest = indexResponse.data?.config?.digest;

--- a/src/registry-factory/DockerhubAdapter.ts
+++ b/src/registry-factory/DockerhubAdapter.ts
@@ -1,5 +1,6 @@
 import logger from "../services/LoggerService";
 import { ImageRegistryAdapter } from "./ImageRegistryAdapter";
+import axios from "axios";
 
 export class DockerhubAdapter extends ImageRegistryAdapter {
     private static readonly DOCKER_API_URL = 'https://hub.docker.com/v2/repositories';

--- a/src/registry-factory/DockerhubAdapter.ts
+++ b/src/registry-factory/DockerhubAdapter.ts
@@ -104,3 +104,4 @@ export class DockerhubAdapter extends ImageRegistryAdapter {
             return null;
         }
     }
+}

--- a/src/registry-factory/DockerhubAdapter.ts
+++ b/src/registry-factory/DockerhubAdapter.ts
@@ -3,6 +3,7 @@ import { ImageRegistryAdapter } from "./ImageRegistryAdapter";
 
 export class DockerhubAdapter extends ImageRegistryAdapter {
     private static readonly DOCKER_API_URL = 'https://hub.docker.com/v2/repositories';
+    private static readonly REGISTRY_API_URL = 'https://registry-1.docker.io/v2';
     private tag: string;
 
     constructor(image: string, tag: string = 'latest', accessToken?: string) {
@@ -68,6 +69,50 @@ export class DockerhubAdapter extends ImageRegistryAdapter {
             logger.error(`Failed to check for new Docker image digest: ${error}`);
             logger.warn(`This might be a locally generated image. To prevent similar issues, exclude it from future MqDockerUp checks (see docs)`);
             throw error;
+        }
+    }
+
+    private getRepoPath(): string {
+        return this.getImageUrl()
+            .replace(`${DockerhubAdapter.DOCKER_API_URL}/`, "")
+            .replace(`/tags/${this.tag}`, "");
+    }
+
+    /**
+     * Resolves the org.opencontainers.image.version label of the tracked tag
+     * by fetching its manifest and config blob from Docker Hub's registry API
+     * (no image pull needed).
+     */
+    async getVersionLabel(): Promise<string | null> {
+        try {
+            const repoPath = this.getRepoPath();
+            const tokenResponse = await this.http.get(
+                `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repoPath}:pull`
+            );
+            const headers = { Authorization: `Bearer ${tokenResponse.data.token}` };
+
+            const indexResponse = await this.http.get(`${DockerhubAdapter.REGISTRY_API_URL}/${repoPath}/manifests/${this.tag}`, {
+                headers: { ...headers, Accept: 'application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' },
+            });
+
+            // Single-arch images return the manifest (with a "config" descriptor) directly;
+            // multi-arch images return an index, so resolve one platform's manifest first.
+            let configDigest = indexResponse.data?.config?.digest;
+            if (!configDigest) {
+                const platformDigest = indexResponse.data?.manifests?.[0]?.digest;
+                if (!platformDigest) return null;
+
+                const manifestResponse = await this.http.get(`${DockerhubAdapter.REGISTRY_API_URL}/${repoPath}/manifests/${platformDigest}`, {
+                    headers: { ...headers, Accept: 'application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' },
+                });
+                configDigest = manifestResponse.data?.config?.digest;
+            }
+            if (!configDigest) return null;
+
+            const configResponse = await this.http.get(`${DockerhubAdapter.REGISTRY_API_URL}/${repoPath}/blobs/${configDigest}`, { headers });
+            return configResponse.data?.config?.Labels?.["org.opencontainers.image.version"] ?? null;
+        } catch (error) {
+            return null;
         }
     }
 }

--- a/src/registry-factory/DockerhubAdapter.ts
+++ b/src/registry-factory/DockerhubAdapter.ts
@@ -86,22 +86,21 @@ export class DockerhubAdapter extends ImageRegistryAdapter {
     async getVersionLabel(): Promise<string | null> {
         try {
             const repoPath = this.getRepoPath();
-            const tokenResponse = await this.http.get(
+            const tokenResponse = await axios.get(
                 `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repoPath}:pull`
             );
             const headers = { Authorization: `Bearer ${tokenResponse.data.token}` };
 
-            const indexResponse = await this.http.get(`${DockerhubAdapter.REGISTRY_API_URL}/${repoPath}/manifests/${this.tag}`, {
+            const indexResponse = await axios.get(`${DockerhubAdapter.REGISTRY_API_URL}/${repoPath}/manifests/${this.tag}`, {
                 headers: { ...headers, Accept: 'application/json' },
             });
 
             let configDigest = indexResponse.data?.config?.digest;
             if (!configDigest) return null;
 
-            const configResponse = await this.http.get(`${DockerhubAdapter.REGISTRY_API_URL}/${repoPath}/blobs/${configDigest}`, { headers });
+            const configResponse = await axios.get(`${DockerhubAdapter.REGISTRY_API_URL}/${repoPath}/blobs/${configDigest}`, { headers });
             return configResponse.data?.config?.Labels?.["org.opencontainers.image.version"] ?? null;
         } catch (error) {
             return null;
         }
     }
-}

--- a/src/registry-factory/GithubAdapter.ts
+++ b/src/registry-factory/GithubAdapter.ts
@@ -83,18 +83,7 @@ export class GithubAdapter extends ImageRegistryAdapter {
                 headers: { Accept: 'application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' },
             });
 
-            // Single-arch images return the manifest (with a "config" descriptor) directly;
-            // multi-arch images return an index, so resolve one platform's manifest first.
             let configDigest = indexResponse.data?.config?.digest;
-            if (!configDigest) {
-                const platformDigest = indexResponse.data?.manifests?.[0]?.digest;
-                if (!platformDigest) return null;
-
-                const manifestResponse = await this.http.get(this.getManifestUrl(platformDigest), {
-                    headers: { Accept: 'application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' },
-                });
-                configDigest = manifestResponse.data?.config?.digest;
-            }
             if (!configDigest) return null;
 
             const configResponse = await this.http.get(this.getBlobUrl(configDigest));

--- a/src/registry-factory/GithubAdapter.ts
+++ b/src/registry-factory/GithubAdapter.ts
@@ -42,6 +42,18 @@ export class GithubAdapter extends ImageRegistryAdapter {
         return `https://${registry}/v2/${user}/${image}/manifests/${this.tag}`;
     }
 
+    private getManifestUrl(reference: string): string {
+        const imageNameWithTag = this.image.split(':')[0];
+        const [registry, user, image] = imageNameWithTag.split('/');
+        return `https://${registry}/v2/${user}/${image}/manifests/${reference}`;
+    }
+
+    private getBlobUrl(digest: string): string {
+        const imageNameWithTag = this.image.split(':')[0];
+        const [registry, user, image] = imageNameWithTag.split('/');
+        return `https://${registry}/v2/${user}/${image}/blobs/${digest}`;
+    }
+
     async checkForNewDigest(): Promise<{ newDigest: string; }> {
         const accessTokenSet = !!config?.accessTokens?.github;
         if (accessTokenSet) {
@@ -59,5 +71,36 @@ export class GithubAdapter extends ImageRegistryAdapter {
         }
 
         return { newDigest: "" };
+    }
+
+    /**
+     * Resolves the org.opencontainers.image.version label of the tracked tag
+     * by fetching its manifest and config blob (no image pull needed).
+     */
+    async getVersionLabel(): Promise<string | null> {
+        try {
+            const indexResponse = await this.http.get(this.getImageUrl(), {
+                headers: { Accept: 'application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' },
+            });
+
+            // Single-arch images return the manifest (with a "config" descriptor) directly;
+            // multi-arch images return an index, so resolve one platform's manifest first.
+            let configDigest = indexResponse.data?.config?.digest;
+            if (!configDigest) {
+                const platformDigest = indexResponse.data?.manifests?.[0]?.digest;
+                if (!platformDigest) return null;
+
+                const manifestResponse = await this.http.get(this.getManifestUrl(platformDigest), {
+                    headers: { Accept: 'application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' },
+                });
+                configDigest = manifestResponse.data?.config?.digest;
+            }
+            if (!configDigest) return null;
+
+            const configResponse = await this.http.get(this.getBlobUrl(configDigest));
+            return configResponse.data?.config?.Labels?.["org.opencontainers.image.version"] ?? null;
+        } catch (error) {
+            return null;
+        }
     }
 }

--- a/src/registry-factory/GithubAdapter.ts
+++ b/src/registry-factory/GithubAdapter.ts
@@ -75,7 +75,7 @@ export class GithubAdapter extends ImageRegistryAdapter {
 
     /**
      * Resolves the org.opencontainers.image.version label of the tracked tag
-     * by fetching its manifest and config blob (no image pull needed).
+     * by fetching its manifest and config blob
      */
     async getVersionLabel(): Promise<string | null> {
         try {

--- a/src/registry-factory/GithubAdapter.ts
+++ b/src/registry-factory/GithubAdapter.ts
@@ -27,7 +27,7 @@ export class GithubAdapter extends ImageRegistryAdapter {
         try {
             const url = new URL(`https://${image}`);
             const host = url.hostname;
-    
+
             // check if the host is exactly 'ghcr.io'
             return host === 'ghcr.io';
         } catch (error) {
@@ -80,7 +80,7 @@ export class GithubAdapter extends ImageRegistryAdapter {
     async getVersionLabel(): Promise<string | null> {
         try {
             const indexResponse = await this.http.get(this.getImageUrl(), {
-                headers: { Accept: 'application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' },
+                headers: { Accept: 'application/json' },
             });
 
             let configDigest = indexResponse.data?.config?.digest;

--- a/src/registry-factory/GithubAdapter.ts
+++ b/src/registry-factory/GithubAdapter.ts
@@ -43,9 +43,10 @@ export class GithubAdapter extends ImageRegistryAdapter {
     }
 
     private getBlobUrl(digest: string): string {
-        const imageNameWithTag = this.image.split(':')[0];
-        const [registry, user, image] = imageNameWithTag.split('/');
-        return `https://${registry}/v2/${user}/${image}/blobs/${digest}`;
+        const parts = this.image.split(':')[0].split('/');
+        const registry = parts[0];
+        const repoPath = parts.slice(1).join('/');
+        return `https://${registry}/v2/${repoPath}/blobs/${digest}`;
     }
 
     async checkForNewDigest(): Promise<{ newDigest: string; }> {

--- a/src/registry-factory/GithubAdapter.ts
+++ b/src/registry-factory/GithubAdapter.ts
@@ -42,12 +42,6 @@ export class GithubAdapter extends ImageRegistryAdapter {
         return `https://${registry}/v2/${user}/${image}/manifests/${this.tag}`;
     }
 
-    private getManifestUrl(reference: string): string {
-        const imageNameWithTag = this.image.split(':')[0];
-        const [registry, user, image] = imageNameWithTag.split('/');
-        return `https://${registry}/v2/${user}/${image}/manifests/${reference}`;
-    }
-
     private getBlobUrl(digest: string): string {
         const imageNameWithTag = this.image.split(':')[0];
         const [registry, user, image] = imageNameWithTag.split('/');

--- a/src/registry-factory/ImageRegistryAdapter.ts
+++ b/src/registry-factory/ImageRegistryAdapter.ts
@@ -28,16 +28,11 @@ export abstract class ImageRegistryAdapter {
 
     abstract checkForNewDigest(): Promise<{ newDigest: string; }>;
 
-    /**
-     * Resolves the org.opencontainers.image.version label of the tracked tag,
-     * without pulling the image. Only worth calling once an update is known
-     * to be available (see checkForNewDigest), since it costs extra requests.
-     */
     abstract getVersionLabel(): Promise<string | null>;
 
     protected removeSHA256Prefix(input: string): string {
         const prefix = "sha256:";
-        
+
         if (input.startsWith(prefix)) {
           return input.slice(prefix.length);
         } else {

--- a/src/registry-factory/ImageRegistryAdapter.ts
+++ b/src/registry-factory/ImageRegistryAdapter.ts
@@ -28,6 +28,13 @@ export abstract class ImageRegistryAdapter {
 
     abstract checkForNewDigest(): Promise<{ newDigest: string; }>;
 
+    /**
+     * Resolves the org.opencontainers.image.version label of the tracked tag,
+     * without pulling the image. Only worth calling once an update is known
+     * to be available (see checkForNewDigest), since it costs extra requests.
+     */
+    abstract getVersionLabel(): Promise<string | null>;
+
     protected removeSHA256Prefix(input: string): string {
         const prefix = "sha256:";
         

--- a/src/registry-factory/LscrAdapter.ts
+++ b/src/registry-factory/LscrAdapter.ts
@@ -1,5 +1,6 @@
 import logger from "../services/LoggerService";
 import { ImageRegistryAdapter } from "./ImageRegistryAdapter";
+import axios from "axios";
 
 export class LscrAdapter extends ImageRegistryAdapter {
     private static readonly DOCKER_API_URL = 'https://hub.docker.com/v2/repositories';

--- a/src/registry-factory/LscrAdapter.ts
+++ b/src/registry-factory/LscrAdapter.ts
@@ -81,3 +81,4 @@ export class LscrAdapter extends ImageRegistryAdapter {
             return null;
         }
     }
+}

--- a/src/registry-factory/LscrAdapter.ts
+++ b/src/registry-factory/LscrAdapter.ts
@@ -71,18 +71,7 @@ export class LscrAdapter extends ImageRegistryAdapter {
                 headers: { ...headers, Accept: 'application/json' },
             });
 
-            // Single-arch images return the manifest (with a "config" descriptor) directly;
-            // multi-arch images return an index, so resolve one platform's manifest first.
             let configDigest = indexResponse.data?.config?.digest;
-            if (!configDigest) {
-                const platformDigest = indexResponse.data?.manifests?.[0]?.digest;
-                if (!platformDigest) return null;
-
-                const manifestResponse = await this.http.get(`${LscrAdapter.REGISTRY_API_URL}/${repoPath}/manifests/${platformDigest}`, {
-                    headers: { ...headers, Accept: 'application/json' },
-                });
-                configDigest = manifestResponse.data?.config?.digest;
-            }
             if (!configDigest) return null;
 
             const configResponse = await this.http.get(`${LscrAdapter.REGISTRY_API_URL}/${repoPath}/blobs/${configDigest}`, { headers });

--- a/src/registry-factory/LscrAdapter.ts
+++ b/src/registry-factory/LscrAdapter.ts
@@ -69,7 +69,7 @@ export class LscrAdapter extends ImageRegistryAdapter {
             const headers = { Authorization: `Bearer ${tokenResponse.data.token}` };
 
             const indexResponse = await this.http.get(`${LscrAdapter.REGISTRY_API_URL}/${repoPath}/manifests/${this.tag}`, {
-                headers: { ...headers, Accept: 'application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' },
+                headers: { ...headers, Accept: 'application/json' },
             });
 
             // Single-arch images return the manifest (with a "config" descriptor) directly;
@@ -80,7 +80,7 @@ export class LscrAdapter extends ImageRegistryAdapter {
                 if (!platformDigest) return null;
 
                 const manifestResponse = await this.http.get(`${LscrAdapter.REGISTRY_API_URL}/${repoPath}/manifests/${platformDigest}`, {
-                    headers: { ...headers, Accept: 'application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' },
+                    headers: { ...headers, Accept: 'application/json' },
                 });
                 configDigest = manifestResponse.data?.config?.digest;
             }

--- a/src/registry-factory/LscrAdapter.ts
+++ b/src/registry-factory/LscrAdapter.ts
@@ -63,22 +63,21 @@ export class LscrAdapter extends ImageRegistryAdapter {
     async getVersionLabel(): Promise<string | null> {
         try {
             const repoPath = this.image.replace('lscr.io/', '');
-            const tokenResponse = await this.http.get(
+            const tokenResponse = await axios.get(
                 `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repoPath}:pull`
             );
             const headers = { Authorization: `Bearer ${tokenResponse.data.token}` };
 
-            const indexResponse = await this.http.get(`${LscrAdapter.REGISTRY_API_URL}/${repoPath}/manifests/${this.tag}`, {
+            const indexResponse = await axios.get(`${LscrAdapter.REGISTRY_API_URL}/${repoPath}/manifests/${this.tag}`, {
                 headers: { ...headers, Accept: 'application/json' },
             });
 
             let configDigest = indexResponse.data?.config?.digest;
             if (!configDigest) return null;
 
-            const configResponse = await this.http.get(`${LscrAdapter.REGISTRY_API_URL}/${repoPath}/blobs/${configDigest}`, { headers });
+            const configResponse = await axios.get(`${LscrAdapter.REGISTRY_API_URL}/${repoPath}/blobs/${configDigest}`, { headers });
             return configResponse.data?.config?.Labels?.["org.opencontainers.image.version"] ?? null;
         } catch (error) {
             return null;
         }
     }
-}

--- a/src/registry-factory/LscrAdapter.ts
+++ b/src/registry-factory/LscrAdapter.ts
@@ -58,7 +58,6 @@ export class LscrAdapter extends ImageRegistryAdapter {
     /**
      * Resolves the org.opencontainers.image.version label of the tracked tag
      * by fetching its manifest and config blob from Docker Hub's registry API
-     * (no image pull needed).
      */
     async getVersionLabel(): Promise<string | null> {
         try {

--- a/src/registry-factory/LscrAdapter.ts
+++ b/src/registry-factory/LscrAdapter.ts
@@ -3,6 +3,7 @@ import { ImageRegistryAdapter } from "./ImageRegistryAdapter";
 
 export class LscrAdapter extends ImageRegistryAdapter {
     private static readonly DOCKER_API_URL = 'https://hub.docker.com/v2/repositories';
+    private static readonly REGISTRY_API_URL = 'https://registry-1.docker.io/v2';
     private tag: string;
 
     constructor(image: string, tag: string = 'latest', accessToken?: string) {
@@ -51,6 +52,44 @@ export class LscrAdapter extends ImageRegistryAdapter {
         } catch (error) {
             logger.error(`Failed to check for new lscr.io image digest: ${error}`);
             throw error;
+        }
+    }
+
+    /**
+     * Resolves the org.opencontainers.image.version label of the tracked tag
+     * by fetching its manifest and config blob from Docker Hub's registry API
+     * (no image pull needed).
+     */
+    async getVersionLabel(): Promise<string | null> {
+        try {
+            const repoPath = this.image.replace('lscr.io/', '');
+            const tokenResponse = await this.http.get(
+                `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repoPath}:pull`
+            );
+            const headers = { Authorization: `Bearer ${tokenResponse.data.token}` };
+
+            const indexResponse = await this.http.get(`${LscrAdapter.REGISTRY_API_URL}/${repoPath}/manifests/${this.tag}`, {
+                headers: { ...headers, Accept: 'application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' },
+            });
+
+            // Single-arch images return the manifest (with a "config" descriptor) directly;
+            // multi-arch images return an index, so resolve one platform's manifest first.
+            let configDigest = indexResponse.data?.config?.digest;
+            if (!configDigest) {
+                const platformDigest = indexResponse.data?.manifests?.[0]?.digest;
+                if (!platformDigest) return null;
+
+                const manifestResponse = await this.http.get(`${LscrAdapter.REGISTRY_API_URL}/${repoPath}/manifests/${platformDigest}`, {
+                    headers: { ...headers, Accept: 'application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' },
+                });
+                configDigest = manifestResponse.data?.config?.digest;
+            }
+            if (!configDigest) return null;
+
+            const configResponse = await this.http.get(`${LscrAdapter.REGISTRY_API_URL}/${repoPath}/blobs/${configDigest}`, { headers });
+            return configResponse.data?.config?.Labels?.["org.opencontainers.image.version"] ?? null;
+        } catch (error) {
+            return null;
         }
     }
 }

--- a/src/services/DockerService.ts
+++ b/src/services/DockerService.ts
@@ -29,7 +29,6 @@ export default class DockerService {
   public static events = new EventEmitter();
   public static updatingContainers: string[] = [];
   public static SourceUrlCache = new Map<string, string>();
-  public static LatestReleaseCache = new Map<string, string>();
 
   // Start listening to Docker events
   public static listenToDockerEvents() {
@@ -122,7 +121,24 @@ export default class DockerService {
       let response = await adapter.checkForNewDigest();
 
       return response.newDigest;
-      
+    } catch (error: any) {
+      logger.error(imageName, tag);
+      logger.error(error);
+      return null;
+    }
+  }
+
+  /**
+   * Gets the version label of the latest available image for the specified
+   * image name. Only worth calling once an update is known to be available,
+   * since resolving it costs extra registry requests.
+   * @param imageName - The name of the Docker image.
+   * @param tag - The tag of the Docker image.
+   */
+  public static async getImageVersionLabel(imageName: string, tag: string): Promise<string | null> {
+    try {
+      let adapter = ImageRegistryAdapterFactory.getAdapter(imageName, tag);
+      return await adapter.getVersionLabel();
     } catch (error: any) {
       logger.error(imageName, tag);
       logger.error(error);
@@ -213,47 +229,6 @@ export default class DockerService {
     }
 
     return null;
-  }
-
-  /**
-   * Gets the latest release tag from a GitHub source repository.
-   * Used to show the actual upstream version instead of a digest.
-   * @param sourceRepo - The source repository URL (e.g. "https://github.com/owner/repo").
-   * @returns A promise that resolves to the latest release tag name, or `null` if it could not be determined.
-   */
-  public static async getLatestGithubReleaseTag(sourceRepo: string): Promise<string | null> {
-    const cached = DockerService.LatestReleaseCache.get(sourceRepo);
-    if (cached) {
-      return cached;
-    }
-
-    let ownerRepo: string | null = null;
-    try {
-      const normalized = /^https?:\/\//i.test(sourceRepo) ? sourceRepo : `https://${sourceRepo}`;
-      const parsedUrl = new URL(normalized);
-
-      if (parsedUrl.hostname !== "github.com") {
-        return null;
-      }
-      ownerRepo = parsedUrl.pathname.replace(/^\//, "").replace(/\.git$/, "").replace(/\/$/, "");
-    } catch (error) {
-      return null;
-    }
-
-    try {
-      const response = await axios.get(`https://api.github.com/repos/${ownerRepo}/releases/latest`);
-      const tagName = response.data?.tag_name ?? null;
-
-      // Cache Tag
-      if (tagName != null) {
-        DockerService.LatestReleaseCache.set(sourceRepo, tagName);
-      }
-
-      return tagName;
-    } catch (error) {
-      logger.warn(`Could not fetch latest GitHub release for ${ownerRepo}`);
-      return null;
-    }
   }
 
   /**

--- a/src/services/DockerService.ts
+++ b/src/services/DockerService.ts
@@ -29,7 +29,7 @@ export default class DockerService {
   public static events = new EventEmitter();
   public static updatingContainers: string[] = [];
   public static SourceUrlCache = new Map<string, string>();
-  public static LatestReleaseCache = new Map<string, string | null>();
+  public static LatestReleaseCache = new Map<string, string>();
 
   // Start listening to Docker events
   public static listenToDockerEvents() {
@@ -223,7 +223,7 @@ export default class DockerService {
    */
   public static async getLatestGithubReleaseTag(sourceRepo: string): Promise<string | null> {
     const cached = DockerService.LatestReleaseCache.get(sourceRepo);
-    if (cached !== undefined) {
+    if (cached) {
       return cached;
     }
 
@@ -231,24 +231,27 @@ export default class DockerService {
     try {
       const normalized = /^https?:\/\//i.test(sourceRepo) ? sourceRepo : `https://${sourceRepo}`;
       const parsedUrl = new URL(normalized);
+
       if (parsedUrl.hostname !== "github.com") {
-        DockerService.LatestReleaseCache.set(sourceRepo, null);
         return null;
       }
       ownerRepo = parsedUrl.pathname.replace(/^\//, "").replace(/\.git$/, "").replace(/\/$/, "");
     } catch (error) {
-      DockerService.LatestReleaseCache.set(sourceRepo, null);
       return null;
     }
 
     try {
       const response = await axios.get(`https://api.github.com/repos/${ownerRepo}/releases/latest`);
       const tagName = response.data?.tag_name ?? null;
-      DockerService.LatestReleaseCache.set(sourceRepo, tagName);
+
+      // Cache Tag
+      if (tagName != null) {
+        DockerService.LatestReleaseCache.set(sourceRepo, tagName);
+      }
+
       return tagName;
     } catch (error) {
       logger.warn(`Could not fetch latest GitHub release for ${ownerRepo}`);
-      DockerService.LatestReleaseCache.set(sourceRepo, null);
       return null;
     }
   }

--- a/src/services/DockerService.ts
+++ b/src/services/DockerService.ts
@@ -129,9 +129,7 @@ export default class DockerService {
   }
 
   /**
-   * Gets the version label of the latest available image for the specified
-   * image name. Only worth calling once an update is known to be available,
-   * since resolving it costs extra registry requests.
+   * Gets the version label of the latest available image for the specified image name.
    * @param imageName - The name of the Docker image.
    * @param tag - The tag of the Docker image.
    */
@@ -246,7 +244,7 @@ export default class DockerService {
       logger.info(`Updating individual container: ${containerId}`);
 
       const container = DockerService.docker.getContainer(containerId);
-      
+
       let info = null
       try {
         info = await container.inspect();
@@ -326,10 +324,10 @@ export default class DockerService {
               try {
                 await container.stop();
                 await container.remove();
-                
+
                 // Remove the old container ID from updatingContainers immediately after removal
                 this.updatingContainers = this.updatingContainers.filter((id) => id !== containerId);
-                
+
                 const newContainer = await DockerService.docker.createContainer(containerConfig);
                 await newContainer.start();
 
@@ -364,7 +362,7 @@ export default class DockerService {
                 const newImage = newContainerInfo.Config.Image.split(":")[0];
                 const newTag = newContainerInfo.Config.Image.split(":")[1] || "latest";
                 const newName = newContainerInfo.Name.startsWith("/") ? newContainerInfo.Name.substring(1) : newContainerInfo.Name;
-                
+
                 // Get topics for old container and publish empty messages to remove from HA
                 await new Promise<void>((resolve) => {
                   DatabaseService.getTopics(containerId, (err: any, topics: any) => {
@@ -373,20 +371,20 @@ export default class DockerService {
                       resolve();
                       return;
                     }
-                    
+
                     // Publish empty messages to all old topics
                     topics.forEach((topic: any) => {
                       HomeassistantService.publishMessage(mqttClient, topic.topic, "", { retain: true, qos: 0 });
                     });
-                    
+
                     resolve();
                   });
                 });
-                
+
                 // Now remove old container from database and add new one
                 await DatabaseService.deleteContainer(containerId);
                 await DatabaseService.addContainer(newContainerInfo.Id, newName, newImage, newTag);
-                
+
                 // Republish update message to show as up-to-date
                 await HomeassistantService.publishImageUpdateMessage(newContainerInfo, mqttClient);
 

--- a/src/services/DockerService.ts
+++ b/src/services/DockerService.ts
@@ -29,6 +29,7 @@ export default class DockerService {
   public static events = new EventEmitter();
   public static updatingContainers: string[] = [];
   public static SourceUrlCache = new Map<string, string>();
+  public static LatestReleaseCache = new Map<string, string | null>();
 
   // Start listening to Docker events
   public static listenToDockerEvents() {
@@ -212,6 +213,44 @@ export default class DockerService {
     }
 
     return null;
+  }
+
+  /**
+   * Gets the latest release tag from a GitHub source repository.
+   * Used to show the actual upstream version instead of a digest.
+   * @param sourceRepo - The source repository URL (e.g. "https://github.com/owner/repo").
+   * @returns A promise that resolves to the latest release tag name, or `null` if it could not be determined.
+   */
+  public static async getLatestGithubReleaseTag(sourceRepo: string): Promise<string | null> {
+    const cached = DockerService.LatestReleaseCache.get(sourceRepo);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    let ownerRepo: string | null = null;
+    try {
+      const normalized = /^https?:\/\//i.test(sourceRepo) ? sourceRepo : `https://${sourceRepo}`;
+      const parsedUrl = new URL(normalized);
+      if (parsedUrl.hostname !== "github.com") {
+        DockerService.LatestReleaseCache.set(sourceRepo, null);
+        return null;
+      }
+      ownerRepo = parsedUrl.pathname.replace(/^\//, "").replace(/\.git$/, "").replace(/\/$/, "");
+    } catch (error) {
+      DockerService.LatestReleaseCache.set(sourceRepo, null);
+      return null;
+    }
+
+    try {
+      const response = await axios.get(`https://api.github.com/repos/${ownerRepo}/releases/latest`);
+      const tagName = response.data?.tag_name ?? null;
+      DockerService.LatestReleaseCache.set(sourceRepo, tagName);
+      return tagName;
+    } catch (error) {
+      logger.warn(`Could not fetch latest GitHub release for ${ownerRepo}`);
+      DockerService.LatestReleaseCache.set(sourceRepo, null);
+      return null;
+    }
   }
 
   /**

--- a/src/services/HomeassistantService.ts
+++ b/src/services/HomeassistantService.ts
@@ -540,13 +540,9 @@ export default class HomeassistantService {
       const installedVersion = versionLabel || `${tag}: ${currentDigest?.substring(0, 12)}`;
 
       let latestVersion = installedVersion;
-      if (newDigest) {
-        if (versionLabel && sourceRepo) {
-          const latestReleaseTag = await DockerService.getLatestGithubReleaseTag(sourceRepo);
-          latestVersion = latestReleaseTag || `${tag}: ${newDigest.substring(0, 12)}`;
-        } else {
-          latestVersion = `${tag}: ${newDigest.substring(0, 12)}`;
-        }
+      if (newDigest && currentDigest !== newDigest) {
+        const newVersion = await DockerService.getImageVersionLabel(image, tag);
+        latestVersion = newVersion || `${tag}: ${newDigest.substring(0, 12)}`;
       }
 
       if (sourceRepo) {

--- a/src/services/HomeassistantService.ts
+++ b/src/services/HomeassistantService.ts
@@ -536,6 +536,18 @@ export default class HomeassistantService {
       const deviceName = TopicService.getDeviceName(container);
       const updateTopic = TopicService.getUpdateTopic(deviceName);
       const sourceRepo = await DockerService.getSourceRepo(image, tag);
+      const versionLabel = imageInfo?.Config?.Labels?.["org.opencontainers.image.version"];
+      const installedVersion = versionLabel || `${tag}: ${currentDigest?.substring(0, 12)}`;
+
+      let latestVersion = installedVersion;
+      if (newDigest) {
+        if (versionLabel && sourceRepo) {
+          const latestReleaseTag = await DockerService.getLatestGithubReleaseTag(sourceRepo);
+          latestVersion = latestReleaseTag || `${tag}: ${newDigest.substring(0, 12)}`;
+        } else {
+          latestVersion = `${tag}: ${newDigest.substring(0, 12)}`;
+        }
+      }
 
       if (sourceRepo) {
         logger.info(`Found source repository: ${sourceRepo}`);
@@ -546,8 +558,8 @@ export default class HomeassistantService {
       let updatePayload: any;
       if (haLegacy) {
         updatePayload = {
-          installed_version: `${tag}: ${currentDigest?.substring(0, 12)}`,
-          latest_version: newDigest ? `${tag}: ${newDigest?.substring(0, 12)}` : null,
+          installed_version: installedVersion,
+          latest_version: newDigest ? latestVersion : null,
           release_notes: null,
           release_url: null,
           entity_picture: null,
@@ -555,8 +567,8 @@ export default class HomeassistantService {
           progress: 0,
           update: {
             state: currentDigest && newDigest && currentDigest !== newDigest ? "available" : "idle",
-            installed_version: `${tag}: ${currentDigest?.substring(0, 12)}`,
-            latest_version: newDigest ? `${tag}: ${newDigest?.substring(0, 12)}` : null,
+            installed_version: installedVersion,
+            latest_version: newDigest ? latestVersion : null,
             last_check: new Date().toISOString(),
             progress: 0,
             remaining: 0,
@@ -574,8 +586,8 @@ export default class HomeassistantService {
         }
       } else {
         updatePayload = {
-          installed_version: `${tag}: ${currentDigest?.substring(0, 12)}`,
-          latest_version: newDigest ? `${tag}: ${newDigest?.substring(0, 12)}` : null,
+          installed_version: installedVersion,
+          latest_version: newDigest ? latestVersion : null,
           release_summary: "",
           release_url: `${sourceRepo ? sourceRepo : "https://github.com/MichelFR/MqDockerUp"}/releases`,
           entity_picture: "https://raw.githubusercontent.com/MichelFR/MqDockerUp/refs/heads/main/assets/logo_200x200.png",

--- a/tests/DockerHubAdapter.test.ts
+++ b/tests/DockerHubAdapter.test.ts
@@ -67,7 +67,7 @@ describe('DockerHubAdapter', () => {
       mockGet.mockReset();
     });
 
-    it('resolves newVersion from the registry config blob for a single-arch image', async () => {
+    it('resolves newVersion from the registry config blob', async () => {
       mockGet.mockImplementation((url: string) => {
         if (url.startsWith('https://auth.docker.io/token')) {
           return Promise.resolve({ data: { token: 'test-token' } });
@@ -88,29 +88,6 @@ describe('DockerHubAdapter', () => {
       expect(mockGet).toHaveBeenCalledWith(
         'https://auth.docker.io/token?service=registry.docker.io&scope=repository:dockerhub-test-1/backend:pull'
       );
-    });
-
-    it('resolves the platform manifest first for a multi-arch index', async () => {
-      mockGet.mockImplementation((url: string) => {
-        if (url.startsWith('https://auth.docker.io/token')) {
-          return Promise.resolve({ data: { token: 'test-token' } });
-        }
-        if (url === 'https://registry-1.docker.io/v2/dockerhub-test-2/backend/manifests/latest') {
-          return Promise.resolve({ data: { manifests: [{ digest: 'sha256:platform1' }] } });
-        }
-        if (url === 'https://registry-1.docker.io/v2/dockerhub-test-2/backend/manifests/sha256:platform1') {
-          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
-        }
-        if (url === 'https://registry-1.docker.io/v2/dockerhub-test-2/backend/blobs/sha256:configdigest') {
-          return Promise.resolve({ data: { config: { Labels: { "org.opencontainers.image.version": "2.15.3" } } } });
-        }
-        return Promise.reject(new Error(`Unexpected URL: ${url}`));
-      });
-
-      const adapter = new DockerhubAdapter('dockerhub-test-2/backend', 'latest');
-      const result = await adapter.getVersionLabel();
-
-      expect(result).toBe('2.15.3');
     });
 
     it('returns null when the config blob has no version label', async () => {

--- a/tests/DockerHubAdapter.test.ts
+++ b/tests/DockerHubAdapter.test.ts
@@ -1,3 +1,9 @@
+const mockGet = jest.fn();
+
+jest.mock("axios", () => ({
+  create: jest.fn(() => ({ get: mockGet })),
+}));
+
 import { DockerhubAdapter } from "../src/registry-factory/DockerhubAdapter";
 
 describe('DockerHubAdapter', () => {
@@ -37,6 +43,94 @@ describe('DockerHubAdapter', () => {
       const url = adapter['getImageUrl']();
 
       expect(url).toEqual('https://hub.docker.com/v2/repositories/library/officialImage/tags/customTag');
+    });
+  });
+
+  describe('checkForNewDigest', () => {
+    beforeEach(() => {
+      mockGet.mockReset();
+    });
+
+    it('resolves the digest without resolving a version label', async () => {
+      mockGet.mockResolvedValue({ data: { digest: 'sha256:abc123', images: [{}] } });
+
+      const adapter = new DockerhubAdapter('dockerhub-test-1/backend', 'latest');
+      const result = await adapter.checkForNewDigest();
+
+      expect(result).toEqual({ newDigest: 'abc123' });
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getVersionLabel', () => {
+    beforeEach(() => {
+      mockGet.mockReset();
+    });
+
+    it('resolves newVersion from the registry config blob for a single-arch image', async () => {
+      mockGet.mockImplementation((url: string) => {
+        if (url.startsWith('https://auth.docker.io/token')) {
+          return Promise.resolve({ data: { token: 'test-token' } });
+        }
+        if (url === 'https://registry-1.docker.io/v2/dockerhub-test-1/backend/manifests/latest') {
+          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
+        }
+        if (url === 'https://registry-1.docker.io/v2/dockerhub-test-1/backend/blobs/sha256:configdigest') {
+          return Promise.resolve({ data: { config: { Labels: { "org.opencontainers.image.version": "2.15.3" } } } });
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+
+      const adapter = new DockerhubAdapter('dockerhub-test-1/backend', 'latest');
+      const result = await adapter.getVersionLabel();
+
+      expect(result).toBe('2.15.3');
+      expect(mockGet).toHaveBeenCalledWith(
+        'https://auth.docker.io/token?service=registry.docker.io&scope=repository:dockerhub-test-1/backend:pull'
+      );
+    });
+
+    it('resolves the platform manifest first for a multi-arch index', async () => {
+      mockGet.mockImplementation((url: string) => {
+        if (url.startsWith('https://auth.docker.io/token')) {
+          return Promise.resolve({ data: { token: 'test-token' } });
+        }
+        if (url === 'https://registry-1.docker.io/v2/dockerhub-test-2/backend/manifests/latest') {
+          return Promise.resolve({ data: { manifests: [{ digest: 'sha256:platform1' }] } });
+        }
+        if (url === 'https://registry-1.docker.io/v2/dockerhub-test-2/backend/manifests/sha256:platform1') {
+          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
+        }
+        if (url === 'https://registry-1.docker.io/v2/dockerhub-test-2/backend/blobs/sha256:configdigest') {
+          return Promise.resolve({ data: { config: { Labels: { "org.opencontainers.image.version": "2.15.3" } } } });
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+
+      const adapter = new DockerhubAdapter('dockerhub-test-2/backend', 'latest');
+      const result = await adapter.getVersionLabel();
+
+      expect(result).toBe('2.15.3');
+    });
+
+    it('returns null when the config blob has no version label', async () => {
+      mockGet.mockImplementation((url: string) => {
+        if (url.startsWith('https://auth.docker.io/token')) {
+          return Promise.resolve({ data: { token: 'test-token' } });
+        }
+        if (url === 'https://registry-1.docker.io/v2/dockerhub-test-3/backend/manifests/latest') {
+          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
+        }
+        if (url === 'https://registry-1.docker.io/v2/dockerhub-test-3/backend/blobs/sha256:configdigest') {
+          return Promise.resolve({ data: { config: { Labels: {} } } });
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+
+      const adapter = new DockerhubAdapter('dockerhub-test-3/backend', 'latest');
+      const result = await adapter.getVersionLabel();
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/tests/DockerHubAdapter.test.ts
+++ b/tests/DockerHubAdapter.test.ts
@@ -2,6 +2,7 @@ const mockGet = jest.fn();
 
 jest.mock("axios", () => ({
   create: jest.fn(() => ({ get: mockGet })),
+  get: mockGet,
 }));
 
 import { DockerhubAdapter } from "../src/registry-factory/DockerhubAdapter";

--- a/tests/DockerHubAdapter.test.ts
+++ b/tests/DockerHubAdapter.test.ts
@@ -47,48 +47,44 @@ describe('DockerHubAdapter', () => {
   });
 
   describe('getVersionLabel', () => {
+    const repoPath = 'dockerhub-test/backend';
+
+    function mockRegistryFlow(version: string | null) {
+      mockGet.mockImplementation((url: string) => {
+        if (url === `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repoPath}:pull`) {
+          return Promise.resolve({ data: { token: 'test-token' } });
+        }
+        if (url === `https://registry-1.docker.io/v2/${repoPath}/manifests/latest`) {
+          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
+        }
+        if (url === `https://registry-1.docker.io/v2/${repoPath}/blobs/sha256:configdigest`) {
+          const labels = version ? { "org.opencontainers.image.version": version } : {};
+          return Promise.resolve({ data: { config: { Labels: labels } } });
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+    }
+
     beforeEach(() => {
       mockGet.mockReset();
     });
 
     it('resolves newVersion from the registry config blob', async () => {
-      mockGet.mockImplementation((url: string) => {
-        if (url.startsWith('https://auth.docker.io/token')) {
-          return Promise.resolve({ data: { token: 'test-token' } });
-        }
-        if (url === 'https://registry-1.docker.io/v2/dockerhub-test-1/backend/manifests/latest') {
-          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
-        }
-        if (url === 'https://registry-1.docker.io/v2/dockerhub-test-1/backend/blobs/sha256:configdigest') {
-          return Promise.resolve({ data: { config: { Labels: { "org.opencontainers.image.version": "2.15.3" } } } });
-        }
-        return Promise.reject(new Error(`Unexpected URL: ${url}`));
-      });
+      mockRegistryFlow('2.15.3');
 
-      const adapter = new DockerhubAdapter('dockerhub-test-1/backend', 'latest');
+      const adapter = new DockerhubAdapter(repoPath, 'latest');
       const result = await adapter.getVersionLabel();
 
       expect(result).toBe('2.15.3');
       expect(mockGet).toHaveBeenCalledWith(
-        'https://auth.docker.io/token?service=registry.docker.io&scope=repository:dockerhub-test-1/backend:pull'
+        `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repoPath}:pull`
       );
     });
 
     it('returns null when the config blob has no version label', async () => {
-      mockGet.mockImplementation((url: string) => {
-        if (url.startsWith('https://auth.docker.io/token')) {
-          return Promise.resolve({ data: { token: 'test-token' } });
-        }
-        if (url === 'https://registry-1.docker.io/v2/dockerhub-test-3/backend/manifests/latest') {
-          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
-        }
-        if (url === 'https://registry-1.docker.io/v2/dockerhub-test-3/backend/blobs/sha256:configdigest') {
-          return Promise.resolve({ data: { config: { Labels: {} } } });
-        }
-        return Promise.reject(new Error(`Unexpected URL: ${url}`));
-      });
+      mockRegistryFlow(null);
 
-      const adapter = new DockerhubAdapter('dockerhub-test-3/backend', 'latest');
+      const adapter = new DockerhubAdapter(repoPath, 'latest');
       const result = await adapter.getVersionLabel();
 
       expect(result).toBeNull();

--- a/tests/DockerHubAdapter.test.ts
+++ b/tests/DockerHubAdapter.test.ts
@@ -46,22 +46,6 @@ describe('DockerHubAdapter', () => {
     });
   });
 
-  describe('checkForNewDigest', () => {
-    beforeEach(() => {
-      mockGet.mockReset();
-    });
-
-    it('resolves the digest without resolving a version label', async () => {
-      mockGet.mockResolvedValue({ data: { digest: 'sha256:abc123', images: [{}] } });
-
-      const adapter = new DockerhubAdapter('dockerhub-test-1/backend', 'latest');
-      const result = await adapter.checkForNewDigest();
-
-      expect(result).toEqual({ newDigest: 'abc123' });
-      expect(mockGet).toHaveBeenCalledTimes(1);
-    });
-  });
-
   describe('getVersionLabel', () => {
     beforeEach(() => {
       mockGet.mockReset();

--- a/tests/DockerService.test.ts
+++ b/tests/DockerService.test.ts
@@ -11,28 +11,6 @@ jest.mock("../src/registry-factory/ImageRegistryAdapterFactory");
 import { ImageRegistryAdapterFactory } from "../src/registry-factory/ImageRegistryAdapterFactory";
 import DockerService from "../src/services/DockerService";
 
-describe("DockerService.getImageNewDigest", () => {
-  it("returns the digest reported by the registry adapter", async () => {
-    (ImageRegistryAdapterFactory.getAdapter as jest.Mock).mockReturnValue({
-      checkForNewDigest: jest.fn().mockResolvedValue({ newDigest: "abc123" }),
-    });
-
-    const result = await DockerService.getImageNewDigest("penpot/backend", "latest");
-
-    expect(result).toBe("abc123");
-  });
-
-  it("returns null when the adapter throws", async () => {
-    (ImageRegistryAdapterFactory.getAdapter as jest.Mock).mockReturnValue({
-      checkForNewDigest: jest.fn().mockRejectedValue(new Error("network error")),
-    });
-
-    const result = await DockerService.getImageNewDigest("penpot/backend", "latest");
-
-    expect(result).toBeNull();
-  });
-});
-
 describe("DockerService.getImageVersionLabel", () => {
   it("returns the version label reported by the registry adapter", async () => {
     (ImageRegistryAdapterFactory.getAdapter as jest.Mock).mockReturnValue({

--- a/tests/DockerService.test.ts
+++ b/tests/DockerService.test.ts
@@ -1,0 +1,54 @@
+jest.mock("../src/index", () => ({
+  mqttClient: {
+    publish: jest.fn(),
+    on: jest.fn(),
+    end: jest.fn(),
+  },
+}));
+
+jest.mock("axios", () => ({
+  get: jest.fn(),
+}));
+
+import axios from "axios";
+import DockerService from "../src/services/DockerService";
+
+describe("DockerService.getLatestGithubReleaseTag", () => {
+  beforeEach(() => {
+    DockerService.LatestReleaseCache.clear();
+    jest.clearAllMocks();
+  });
+
+  it("returns the latest release tag for a GitHub repository", async () => {
+    (axios.get as jest.Mock).mockResolvedValue({ data: { tag_name: "2.15.3" } });
+
+    const result = await DockerService.getLatestGithubReleaseTag("https://github.com/penpot/penpot");
+
+    expect(result).toBe("2.15.3");
+    expect(axios.get).toHaveBeenCalledWith("https://api.github.com/repos/penpot/penpot/releases/latest");
+  });
+
+  it("caches the result so subsequent calls do not hit the network again", async () => {
+    (axios.get as jest.Mock).mockResolvedValue({ data: { tag_name: "2.15.3" } });
+
+    await DockerService.getLatestGithubReleaseTag("https://github.com/penpot/penpot");
+    await DockerService.getLatestGithubReleaseTag("https://github.com/penpot/penpot");
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null for non-GitHub repositories", async () => {
+    const result = await DockerService.getLatestGithubReleaseTag("https://gitlab.com/group/project");
+
+    expect(result).toBeNull();
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the GitHub API request fails", async () => {
+    (axios.get as jest.Mock).mockRejectedValue(new Error("not found"));
+
+    const result = await DockerService.getLatestGithubReleaseTag("https://github.com/owner/repo");
+
+    expect(result).toBeNull();
+  });
+});

--- a/tests/DockerService.test.ts
+++ b/tests/DockerService.test.ts
@@ -6,48 +6,50 @@ jest.mock("../src/index", () => ({
   },
 }));
 
-jest.mock("axios", () => ({
-  get: jest.fn(),
-}));
+jest.mock("../src/registry-factory/ImageRegistryAdapterFactory");
 
-import axios from "axios";
+import { ImageRegistryAdapterFactory } from "../src/registry-factory/ImageRegistryAdapterFactory";
 import DockerService from "../src/services/DockerService";
 
-describe("DockerService.getLatestGithubReleaseTag", () => {
-  beforeEach(() => {
-    DockerService.LatestReleaseCache.clear();
-    jest.clearAllMocks();
+describe("DockerService.getImageNewDigest", () => {
+  it("returns the digest reported by the registry adapter", async () => {
+    (ImageRegistryAdapterFactory.getAdapter as jest.Mock).mockReturnValue({
+      checkForNewDigest: jest.fn().mockResolvedValue({ newDigest: "abc123" }),
+    });
+
+    const result = await DockerService.getImageNewDigest("penpot/backend", "latest");
+
+    expect(result).toBe("abc123");
   });
 
-  it("returns the latest release tag for a GitHub repository", async () => {
-    (axios.get as jest.Mock).mockResolvedValue({ data: { tag_name: "2.15.3" } });
+  it("returns null when the adapter throws", async () => {
+    (ImageRegistryAdapterFactory.getAdapter as jest.Mock).mockReturnValue({
+      checkForNewDigest: jest.fn().mockRejectedValue(new Error("network error")),
+    });
 
-    const result = await DockerService.getLatestGithubReleaseTag("https://github.com/penpot/penpot");
-
-    expect(result).toBe("2.15.3");
-    expect(axios.get).toHaveBeenCalledWith("https://api.github.com/repos/penpot/penpot/releases/latest");
-  });
-
-  it("caches the result so subsequent calls do not hit the network again", async () => {
-    (axios.get as jest.Mock).mockResolvedValue({ data: { tag_name: "2.15.3" } });
-
-    await DockerService.getLatestGithubReleaseTag("https://github.com/penpot/penpot");
-    await DockerService.getLatestGithubReleaseTag("https://github.com/penpot/penpot");
-
-    expect(axios.get).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns null for non-GitHub repositories", async () => {
-    const result = await DockerService.getLatestGithubReleaseTag("https://gitlab.com/group/project");
+    const result = await DockerService.getImageNewDigest("penpot/backend", "latest");
 
     expect(result).toBeNull();
-    expect(axios.get).not.toHaveBeenCalled();
+  });
+});
+
+describe("DockerService.getImageVersionLabel", () => {
+  it("returns the version label reported by the registry adapter", async () => {
+    (ImageRegistryAdapterFactory.getAdapter as jest.Mock).mockReturnValue({
+      getVersionLabel: jest.fn().mockResolvedValue("2.15.3"),
+    });
+
+    const result = await DockerService.getImageVersionLabel("penpot/backend", "latest");
+
+    expect(result).toBe("2.15.3");
   });
 
-  it("returns null when the GitHub API request fails", async () => {
-    (axios.get as jest.Mock).mockRejectedValue(new Error("not found"));
+  it("returns null when the adapter throws", async () => {
+    (ImageRegistryAdapterFactory.getAdapter as jest.Mock).mockReturnValue({
+      getVersionLabel: jest.fn().mockRejectedValue(new Error("network error")),
+    });
 
-    const result = await DockerService.getLatestGithubReleaseTag("https://github.com/owner/repo");
+    const result = await DockerService.getImageVersionLabel("penpot/backend", "latest");
 
     expect(result).toBeNull();
   });

--- a/tests/GithubAdapter.test.ts
+++ b/tests/GithubAdapter.test.ts
@@ -1,3 +1,18 @@
+const mockGet = jest.fn();
+
+jest.mock("axios", () => ({
+  create: jest.fn(() => ({ get: mockGet, defaults: { headers: {} } })),
+}));
+
+jest.mock("../src/services/ConfigService", () => ({
+  __esModule: true,
+  default: {
+    getConfig: () => ({
+      accessTokens: { github: "test-token" },
+    }),
+  },
+}));
+
 import { GithubAdapter } from "../src/registry-factory/GithubAdapter";
 
 describe('GithubAdapter', () => {
@@ -36,6 +51,82 @@ describe('GithubAdapter', () => {
       const url = adapter['getImageUrl']();
 
       expect(url).toEqual('https://ghcr.io/v2/user/image/manifests/latest');
+    });
+  });
+
+  describe('checkForNewDigest', () => {
+    beforeEach(() => {
+      mockGet.mockReset();
+    });
+
+    it('resolves only the digest, without resolving a version label', async () => {
+      mockGet.mockResolvedValue({ headers: { 'docker-content-digest': 'sha256:abc123' } });
+
+      const adapter = new GithubAdapter('ghcr.io/user/image', 'latest');
+      const result = await adapter.checkForNewDigest();
+
+      expect(result).toEqual({ newDigest: 'abc123' });
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getVersionLabel', () => {
+    beforeEach(() => {
+      mockGet.mockReset();
+    });
+
+    it('resolves newVersion from the config blob for a single-arch image', async () => {
+      mockGet.mockImplementation((url: string) => {
+        if (url === 'https://ghcr.io/v2/user/image/manifests/latest') {
+          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
+        }
+        if (url === 'https://ghcr.io/v2/user/image/blobs/sha256:configdigest') {
+          return Promise.resolve({ data: { config: { Labels: { "org.opencontainers.image.version": "2.15.3" } } } });
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+
+      const adapter = new GithubAdapter('ghcr.io/user/image', 'latest');
+      const result = await adapter.getVersionLabel();
+
+      expect(result).toBe('2.15.3');
+    });
+
+    it('resolves the platform manifest first for a multi-arch index', async () => {
+      mockGet.mockImplementation((url: string) => {
+        if (url === 'https://ghcr.io/v2/user/image/manifests/latest') {
+          return Promise.resolve({ data: { manifests: [{ digest: 'sha256:platform1' }] } });
+        }
+        if (url === 'https://ghcr.io/v2/user/image/manifests/sha256:platform1') {
+          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
+        }
+        if (url === 'https://ghcr.io/v2/user/image/blobs/sha256:configdigest') {
+          return Promise.resolve({ data: { config: { Labels: { "org.opencontainers.image.version": "2.15.3" } } } });
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+
+      const adapter = new GithubAdapter('ghcr.io/user/image', 'latest');
+      const result = await adapter.getVersionLabel();
+
+      expect(result).toBe('2.15.3');
+    });
+
+    it('returns null when the config blob has no version label', async () => {
+      mockGet.mockImplementation((url: string) => {
+        if (url === 'https://ghcr.io/v2/user/image/manifests/latest') {
+          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
+        }
+        if (url === 'https://ghcr.io/v2/user/image/blobs/sha256:configdigest') {
+          return Promise.resolve({ data: { config: { Labels: {} } } });
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+
+      const adapter = new GithubAdapter('ghcr.io/user/image', 'latest');
+      const result = await adapter.getVersionLabel();
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/tests/GithubAdapter.test.ts
+++ b/tests/GithubAdapter.test.ts
@@ -54,22 +54,6 @@ describe('GithubAdapter', () => {
     });
   });
 
-  describe('checkForNewDigest', () => {
-    beforeEach(() => {
-      mockGet.mockReset();
-    });
-
-    it('resolves only the digest, without resolving a version label', async () => {
-      mockGet.mockResolvedValue({ headers: { 'docker-content-digest': 'sha256:abc123' } });
-
-      const adapter = new GithubAdapter('ghcr.io/user/image', 'latest');
-      const result = await adapter.checkForNewDigest();
-
-      expect(result).toEqual({ newDigest: 'abc123' });
-      expect(mockGet).toHaveBeenCalledTimes(1);
-    });
-  });
-
   describe('getVersionLabel', () => {
     beforeEach(() => {
       mockGet.mockReset();

--- a/tests/GithubAdapter.test.ts
+++ b/tests/GithubAdapter.test.ts
@@ -55,20 +55,25 @@ describe('GithubAdapter', () => {
   });
 
   describe('getVersionLabel', () => {
-    beforeEach(() => {
-      mockGet.mockReset();
-    });
-
-    it('resolves newVersion from the config blob', async () => {
+    function mockRegistryFlow(version: string | null) {
       mockGet.mockImplementation((url: string) => {
         if (url === 'https://ghcr.io/v2/user/image/manifests/latest') {
           return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
         }
         if (url === 'https://ghcr.io/v2/user/image/blobs/sha256:configdigest') {
-          return Promise.resolve({ data: { config: { Labels: { "org.opencontainers.image.version": "2.15.3" } } } });
+          const labels = version ? { "org.opencontainers.image.version": version } : {};
+          return Promise.resolve({ data: { config: { Labels: labels } } });
         }
         return Promise.reject(new Error(`Unexpected URL: ${url}`));
       });
+    }
+
+    beforeEach(() => {
+      mockGet.mockReset();
+    });
+
+    it('resolves newVersion from the config blob', async () => {
+      mockRegistryFlow('2.15.3');
 
       const adapter = new GithubAdapter('ghcr.io/user/image', 'latest');
       const result = await adapter.getVersionLabel();
@@ -77,15 +82,7 @@ describe('GithubAdapter', () => {
     });
 
     it('returns null when the config blob has no version label', async () => {
-      mockGet.mockImplementation((url: string) => {
-        if (url === 'https://ghcr.io/v2/user/image/manifests/latest') {
-          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
-        }
-        if (url === 'https://ghcr.io/v2/user/image/blobs/sha256:configdigest') {
-          return Promise.resolve({ data: { config: { Labels: {} } } });
-        }
-        return Promise.reject(new Error(`Unexpected URL: ${url}`));
-      });
+      mockRegistryFlow(null);
 
       const adapter = new GithubAdapter('ghcr.io/user/image', 'latest');
       const result = await adapter.getVersionLabel();

--- a/tests/GithubAdapter.test.ts
+++ b/tests/GithubAdapter.test.ts
@@ -75,29 +75,9 @@ describe('GithubAdapter', () => {
       mockGet.mockReset();
     });
 
-    it('resolves newVersion from the config blob for a single-arch image', async () => {
+    it('resolves newVersion from the config blob', async () => {
       mockGet.mockImplementation((url: string) => {
         if (url === 'https://ghcr.io/v2/user/image/manifests/latest') {
-          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
-        }
-        if (url === 'https://ghcr.io/v2/user/image/blobs/sha256:configdigest') {
-          return Promise.resolve({ data: { config: { Labels: { "org.opencontainers.image.version": "2.15.3" } } } });
-        }
-        return Promise.reject(new Error(`Unexpected URL: ${url}`));
-      });
-
-      const adapter = new GithubAdapter('ghcr.io/user/image', 'latest');
-      const result = await adapter.getVersionLabel();
-
-      expect(result).toBe('2.15.3');
-    });
-
-    it('resolves the platform manifest first for a multi-arch index', async () => {
-      mockGet.mockImplementation((url: string) => {
-        if (url === 'https://ghcr.io/v2/user/image/manifests/latest') {
-          return Promise.resolve({ data: { manifests: [{ digest: 'sha256:platform1' }] } });
-        }
-        if (url === 'https://ghcr.io/v2/user/image/manifests/sha256:platform1') {
           return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
         }
         if (url === 'https://ghcr.io/v2/user/image/blobs/sha256:configdigest') {

--- a/tests/LscrAdapter.test.ts
+++ b/tests/LscrAdapter.test.ts
@@ -45,22 +45,6 @@ describe('LscrAdapter', () => {
     });
   });
 
-  describe('checkForNewDigest', () => {
-    beforeEach(() => {
-      mockGet.mockReset();
-    });
-
-    it('resolves the digest without resolving a version label', async () => {
-      mockGet.mockResolvedValue({ data: { results: [{ digest: 'sha256:abc123', images: [{}] }] } });
-
-      const adapter = new LscrAdapter('lscr.io/lscr-test-1/backend', 'latest');
-      const result = await adapter.checkForNewDigest();
-
-      expect(result).toEqual({ newDigest: 'abc123' });
-      expect(mockGet).toHaveBeenCalledTimes(1);
-    });
-  });
-
   describe('getVersionLabel', () => {
     beforeEach(() => {
       mockGet.mockReset();

--- a/tests/LscrAdapter.test.ts
+++ b/tests/LscrAdapter.test.ts
@@ -46,48 +46,44 @@ describe('LscrAdapter', () => {
   });
 
   describe('getVersionLabel', () => {
+    const repoPath = 'lscr-test/backend';
+
+    function mockRegistryFlow(version: string | null) {
+      mockGet.mockImplementation((url: string) => {
+        if (url === `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repoPath}:pull`) {
+          return Promise.resolve({ data: { token: 'test-token' } });
+        }
+        if (url === `https://registry-1.docker.io/v2/${repoPath}/manifests/latest`) {
+          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
+        }
+        if (url === `https://registry-1.docker.io/v2/${repoPath}/blobs/sha256:configdigest`) {
+          const labels = version ? { "org.opencontainers.image.version": version } : {};
+          return Promise.resolve({ data: { config: { Labels: labels } } });
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+    }
+
     beforeEach(() => {
       mockGet.mockReset();
     });
 
     it('resolves newVersion from the registry config blob', async () => {
-      mockGet.mockImplementation((url: string) => {
-        if (url.startsWith('https://auth.docker.io/token')) {
-          return Promise.resolve({ data: { token: 'test-token' } });
-        }
-        if (url === 'https://registry-1.docker.io/v2/lscr-test-1/backend/manifests/latest') {
-          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
-        }
-        if (url === 'https://registry-1.docker.io/v2/lscr-test-1/backend/blobs/sha256:configdigest') {
-          return Promise.resolve({ data: { config: { Labels: { "org.opencontainers.image.version": "2.15.3" } } } });
-        }
-        return Promise.reject(new Error(`Unexpected URL: ${url}`));
-      });
+      mockRegistryFlow('2.15.3');
 
-      const adapter = new LscrAdapter('lscr.io/lscr-test-1/backend', 'latest');
+      const adapter = new LscrAdapter(`lscr.io/${repoPath}`, 'latest');
       const result = await adapter.getVersionLabel();
 
       expect(result).toBe('2.15.3');
       expect(mockGet).toHaveBeenCalledWith(
-        'https://auth.docker.io/token?service=registry.docker.io&scope=repository:lscr-test-1/backend:pull'
+        `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repoPath}:pull`
       );
     });
 
     it('returns null when the config blob has no version label', async () => {
-      mockGet.mockImplementation((url: string) => {
-        if (url.startsWith('https://auth.docker.io/token')) {
-          return Promise.resolve({ data: { token: 'test-token' } });
-        }
-        if (url === 'https://registry-1.docker.io/v2/lscr-test-2/backend/manifests/latest') {
-          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
-        }
-        if (url === 'https://registry-1.docker.io/v2/lscr-test-2/backend/blobs/sha256:configdigest') {
-          return Promise.resolve({ data: { config: { Labels: {} } } });
-        }
-        return Promise.reject(new Error(`Unexpected URL: ${url}`));
-      });
+      mockRegistryFlow(null);
 
-      const adapter = new LscrAdapter('lscr.io/lscr-test-2/backend', 'latest');
+      const adapter = new LscrAdapter(`lscr.io/${repoPath}`, 'latest');
       const result = await adapter.getVersionLabel();
 
       expect(result).toBeNull();

--- a/tests/LscrAdapter.test.ts
+++ b/tests/LscrAdapter.test.ts
@@ -2,6 +2,7 @@ const mockGet = jest.fn();
 
 jest.mock("axios", () => ({
   create: jest.fn(() => ({ get: mockGet })),
+  get: mockGet,
 }));
 
 import { LscrAdapter } from "../src/registry-factory/LscrAdapter";

--- a/tests/LscrAdapter.test.ts
+++ b/tests/LscrAdapter.test.ts
@@ -1,3 +1,9 @@
+const mockGet = jest.fn();
+
+jest.mock("axios", () => ({
+  create: jest.fn(() => ({ get: mockGet })),
+}));
+
 import { LscrAdapter } from "../src/registry-factory/LscrAdapter";
 
 describe('LscrAdapter', () => {
@@ -36,6 +42,71 @@ describe('LscrAdapter', () => {
       const url = adapter['getImageUrl']();
 
       expect(url).toEqual('https://hub.docker.com/v2/repositories/user/image/tags?name=latest');
+    });
+  });
+
+  describe('checkForNewDigest', () => {
+    beforeEach(() => {
+      mockGet.mockReset();
+    });
+
+    it('resolves the digest without resolving a version label', async () => {
+      mockGet.mockResolvedValue({ data: { results: [{ digest: 'sha256:abc123', images: [{}] }] } });
+
+      const adapter = new LscrAdapter('lscr.io/lscr-test-1/backend', 'latest');
+      const result = await adapter.checkForNewDigest();
+
+      expect(result).toEqual({ newDigest: 'abc123' });
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getVersionLabel', () => {
+    beforeEach(() => {
+      mockGet.mockReset();
+    });
+
+    it('resolves newVersion from the registry config blob', async () => {
+      mockGet.mockImplementation((url: string) => {
+        if (url.startsWith('https://auth.docker.io/token')) {
+          return Promise.resolve({ data: { token: 'test-token' } });
+        }
+        if (url === 'https://registry-1.docker.io/v2/lscr-test-1/backend/manifests/latest') {
+          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
+        }
+        if (url === 'https://registry-1.docker.io/v2/lscr-test-1/backend/blobs/sha256:configdigest') {
+          return Promise.resolve({ data: { config: { Labels: { "org.opencontainers.image.version": "2.15.3" } } } });
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+
+      const adapter = new LscrAdapter('lscr.io/lscr-test-1/backend', 'latest');
+      const result = await adapter.getVersionLabel();
+
+      expect(result).toBe('2.15.3');
+      expect(mockGet).toHaveBeenCalledWith(
+        'https://auth.docker.io/token?service=registry.docker.io&scope=repository:lscr-test-1/backend:pull'
+      );
+    });
+
+    it('returns null when the config blob has no version label', async () => {
+      mockGet.mockImplementation((url: string) => {
+        if (url.startsWith('https://auth.docker.io/token')) {
+          return Promise.resolve({ data: { token: 'test-token' } });
+        }
+        if (url === 'https://registry-1.docker.io/v2/lscr-test-2/backend/manifests/latest') {
+          return Promise.resolve({ data: { config: { digest: 'sha256:configdigest' } } });
+        }
+        if (url === 'https://registry-1.docker.io/v2/lscr-test-2/backend/blobs/sha256:configdigest') {
+          return Promise.resolve({ data: { config: { Labels: {} } } });
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+
+      const adapter = new LscrAdapter('lscr.io/lscr-test-2/backend', 'latest');
+      const result = await adapter.getVersionLabel();
+
+      expect(result).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Replaces the Digest Hash with actual versions in the HA Update Prompt:
<img width="1168" height="700" alt="image" src="https://github.com/user-attachments/assets/165a58a3-880c-40a3-b1c2-d2ea30f94be7" />

Thisl uses "org.opencontainers.image.version" from the metadata of the new image, so images which don't set this label will still show the old digtest.

NOTICE: The code in this PR was greatly created via generative AI. All code was reviewed and tested by a Human.

closes #639